### PR TITLE
Resolves SparkleXrm issue #93

### DIFF
--- a/SparkleXrmSamples/ConnectionsUI/ClientUI/ViewModel/ObservableConnection.cs
+++ b/SparkleXrmSamples/ConnectionsUI/ClientUI/ViewModel/ObservableConnection.cs
@@ -80,7 +80,11 @@ namespace ClientUI.ViewModel
                         // We use col<n> as the alias name so that we can show the correct values irrespective of the entity type
                         string aliasName = "col" + i.ToString();
                         row[aliasName] = row[config.Columns[i].Field];
-                        entityRow.FormattedValues[aliasName + "name"] = entityRow.FormattedValues[config.Columns[i].Field + "name"];
+                        if (entityRow.FormattedValues.ContainsKey(config.Columns[i].Field + "name")) {
+                            entityRow.FormattedValues[aliasName + "name"] = entityRow.FormattedValues[config.Columns[i].Field + "name"];
+                        } else {
+                            entityRow.FormattedValues[aliasName] = entityRow.GetAttributeValue(config.Columns[i].Field) as string;
+                        }
                     }
 
                 }
@@ -106,7 +110,7 @@ namespace ClientUI.ViewModel
         private void SearchRecords(string term, Action<EntityCollection> callback, string entityType)
         {
            
-            string fetchXml = _queryParser.GetFetchXmlForQuery(entityType,"QuickFind", "%" + term +"%");
+            string fetchXml = _queryParser.GetFetchXmlForQuery(entityType,"QuickFind", term, SearchTermOptions.PrefixWildcard | SearchTermOptions.SuffixWildcard);
 
             
             OrganizationServiceProxy.BeginRetrieveMultiple(fetchXml, delegate(object result)

--- a/SparkleXrmSamples/ConnectionsUI/ClientUI/ViewModel/QueryParser.cs
+++ b/SparkleXrmSamples/ConnectionsUI/ClientUI/ViewModel/QueryParser.cs
@@ -297,6 +297,7 @@ namespace ClientUI.ViewModels
                 link.Attributes = new Dictionary<string, AttributeQuery>();
                 link.AliasName = element.GetAttribute("alias").ToString();
                 link.LogicalName =  element.GetAttribute("name").ToString();
+                link.Views = new Dictionary<string, FetchQuerySettings>();
 
                 if (!EntityLookup.ContainsKey(link.LogicalName))
                 {

--- a/SparkleXrmSamples/ConnectionsUI/ClientUI/ViewModel/QueryParser.cs
+++ b/SparkleXrmSamples/ConnectionsUI/ClientUI/ViewModel/QueryParser.cs
@@ -125,8 +125,14 @@ namespace ClientUI.ViewModels
            
             FetchQuerySettings querySettings = new FetchQuerySettings();
             
-           
-            jQueryObject fetchXmlDOM = jQuery.FromHtml("<query>" + fetchXml.Replace("{0}", "#Query#") + "</query>");
+            //Quick find view features placeholders from {0} up to {4} based on attribute type.
+            jQueryObject fetchXmlDOM = jQuery.FromHtml("<query>" + fetchXml
+                    .Replace("{0}", "#Query#") 
+                    .Replace("{1}", "#QueryInt#") 
+                    .Replace("{2}", "#QueryCurrency#")
+                    .Replace("{3}", "#QueryDateTime#")
+                    .Replace("{4}", "#QueryFloat#")
+                + "</query>");
             jQueryObject fetchElement = fetchXmlDOM.Find("fetch");
             querySettings.FetchXml = fetchXmlDOM;
 
@@ -339,7 +345,7 @@ namespace ClientUI.ViewModels
 
         }
                
-        public string GetFetchXmlForQuery(string entityLogicalName, string queryName, string searchTerm)
+        public string GetFetchXmlForQuery(string entityLogicalName, string queryName, string searchTerm, SearchTermOptions searchOptions)
         {
             FetchQuerySettings config;
             if (queryName == "QuickFind")
@@ -350,7 +356,7 @@ namespace ClientUI.ViewModels
             {
                 config = EntityLookup[entityLogicalName].Views[queryName];
             }
-            jQueryObject fetchElement = config.FetchXml.Find("fetch");
+            jQueryObject fetchElement = config.FetchXml.Clone().Find("fetch");
          
             fetchElement.Attribute("distinct", "true");
             fetchElement.Attribute("no-lock", "true");
@@ -370,11 +376,55 @@ namespace ClientUI.ViewModels
                     element.SetAttribute("attribute", logicalName + "name");
                 }
             });
+
+            //See what field types can we use for query and remove those attributes we cannot query using this search term.
+            if (Number.IsNaN(Int32.Parse(searchTerm)))
+            {
+                fetchElement.Find("condition[value='#QueryInt#']").Remove();
+            }
+            if (Number.IsNaN(Decimal.Parse(searchTerm)))
+            {
+                fetchElement.Find("condition[value='#QueryCurrency#']").Remove();
+            }
+            if (Number.IsNaN(Date.Parse(searchTerm).GetDate()))
+            {
+                fetchElement.Find("condition[value='#QueryDateTime#']").Remove();
+            }
+            if (Number.IsNaN(Double.Parse(searchTerm)))
+            {
+                fetchElement.Find("condition[value='#QueryFloat#']").Remove();
+            }
             // Add the sort order placeholder
-            string fetchXml = config.FetchXml.GetHtml();//.Replace("</entity>", "{3}</entity>");
+            string fetchXml = fetchElement.Parent().GetHtml();//.Replace("</entity>", "{3}</entity>");
+
+            //Prepare search term based on options
+            string textSearchTerm = searchTerm;
+            if (searchOptions != null && (searchOptions & SearchTermOptions.PrefixWildcard) == SearchTermOptions.PrefixWildcard)
+            {
+                //Trimming, in case there are already wildcards with user input
+                while (textSearchTerm.StartsWith("*") || textSearchTerm.StartsWith("%"))
+                {
+                    textSearchTerm = textSearchTerm.Substring(1, textSearchTerm.Length);
+                }
+                textSearchTerm = "%" + textSearchTerm;
+            }
+            if (searchOptions != null && (searchOptions & SearchTermOptions.SuffixWildcard) == SearchTermOptions.SuffixWildcard)
+            {
+                //Trimming, in case there are already wildcards
+                while (textSearchTerm.EndsWith("*") || textSearchTerm.EndsWith("%"))
+                {
+                    textSearchTerm = textSearchTerm.Substring(0, textSearchTerm.Length - 1);
+                }
+                textSearchTerm = textSearchTerm + "%";
+            }
 
             // Add the Query term
-            fetchXml = fetchXml.Replace("#Query#", XmlHelper.Encode(searchTerm));
+            fetchXml = fetchXml.Replace("#Query#", XmlHelper.Encode(textSearchTerm))            
+                .Replace("#QueryInt#", Int32.Parse(searchTerm).ToString())
+                .Replace("#QueryCurrency#", Double.Parse(searchTerm).ToString())
+                .Replace("#QueryDateTime#", XmlHelper.Encode(Date.Parse(searchTerm).Format("MM/dd/yyyy")))
+                .Replace("#QueryFloat#", Double.Parse(searchTerm).ToString());
+
             return fetchXml;
         }
         public static string GetFetchXmlParentFilter(FetchQuerySettings query, string parentAttribute)
@@ -423,6 +473,15 @@ namespace ClientUI.ViewModels
             // Add the order by placeholder for the EntityDataViewModel
             return query.FetchXml.GetHtml().Replace("</entity>", "{3}</entity>");
         }
+    }
+
+    [IgnoreNamespace]
+    [Flags]
+    public enum SearchTermOptions
+    {
+        None = 0,
+        PrefixWildcard = 1,
+        SuffixWildcard = 2
     }
 
     [Imported]


### PR DESCRIPTION
Resolves: ConnectionUI lookup of new record doesn't work with specific quickfind FetchXML
Be sure to initiate View property when parsing link-entity element.