### PR TITLE
spkl: Plugin assembly and steps not beeing added to solution

### DIFF
--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -244,7 +244,7 @@ namespace SparkleXrm.Tasks
             // Add to solution
             if (SolutionUniqueName != null)
             {
-                _trace.WriteLine("Adding Plugin '{0}' to solution {1}", plugin.Name);
+                _trace.WriteLine("Adding Plugin '{0}' to solution '{1}'", plugin.Name, SolutionUniqueName);
                 AddAssemblyToSolution(SolutionUniqueName, plugin);
             }
             return plugin;

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsTask.cs
@@ -46,6 +46,11 @@ namespace SparkleXrm.Tasks
 
                 var pluginRegistration = new PluginRegistraton(_service, ctx, _trace);
 
+                if (!string.IsNullOrEmpty(plugin.solution))
+                {
+                    pluginRegistration.SolutionUniqueName = plugin.solution;
+                }
+
                 foreach (var assemblyFilePath in assemblies)
                 {
                     try


### PR DESCRIPTION
Even if solution is specified i spkl.json it is not beeing used. Fixed by setting SolutionUniqueName property of PluginRegistraton instance. 

Also fixed a bug (missing param 2) in traceoutput.