### PR TITLE
Fix friendly name not being set & error w/ empty string

### DIFF
--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -94,7 +94,7 @@ namespace SparkleXrm.Tasks
                     sdkPluginType.PluginAssemblyId = plugin.ToEntityReference();
                     sdkPluginType.TypeName = pluginType.FullName;
 
-                    sdkPluginType.FriendlyName = sdkPluginType.FriendlyName != null ? sdkPluginType.FriendlyName : Guid.NewGuid().ToString();
+                    sdkPluginType.FriendlyName = !string.IsNullOrEmpty(workflowActivitiy.FriendlyName) ? workflowActivitiy.FriendlyName : Guid.NewGuid().ToString();
                     sdkPluginType.WorkflowActivityGroupName = workflowActivitiy.GroupName;
                     sdkPluginType.Description = workflowActivitiy.Description;
 


### PR DESCRIPTION
In order to retain the friendly name on fresh registrations, check the workflowActivity.FriendlyName. Also added emtpy string check as that isn't allowed - multiple empty spaces are OK though - go figure