### PR TITLE
O365 security enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ UpgradeLog*.XML
 /NuGet/ScriptSharpVSIX/.vs/ScriptSharpVSIX/v15/sqlite3/storage.ide
 /spkl/XmlDiffLib
 /spkl.fakes/.vs/spkl.fakes/v15/sqlite3
+/spkl/.vs/spkl/v15/Server/sqlite3

--- a/spkl/spkl/CommandLineArgs.cs
+++ b/spkl/spkl/CommandLineArgs.cs
@@ -36,5 +36,8 @@ get-webresources = Download webresources and match to the local files to create 
 
         [CommandLineParameter(Name = "Wait for keypress", Command = "w", Required = false, Description = "Optional wait for a key press at the end of task run")]
         public bool WaitForKey { get; set; }
+
+        [CommandLineParameter(Name = "Ignore Windows login", Command = "i", Required = false, Description = "Optional flag to ignore logged in windows credentials during discovery and always ask for username/password.")]
+        public bool IgnoreLocalPrincipal { get; set; }
     }
 }

--- a/spkl/spkl/CrmServiceHelpers.cs
+++ b/spkl/spkl/CrmServiceHelpers.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Crm.Sdk.Samples
             public ClientCredentials Credentials = null;
             public AuthenticationProviderType EndpointType;
             public String UserPrincipalName;
+            public bool IgnoreLocalPrincipal;
             #region internal members of the class
             internal IServiceManagement<IOrganizationService> OrganizationServiceManagement;
             internal SecurityTokenResponse OrganizationTokenResponse;            
@@ -193,7 +194,7 @@ namespace Microsoft.Crm.Sdk.Samples
         /// Obtains the server connection information including the target organization's
         /// Uri and user logon credentials from the user.
         /// </summary>
-        public virtual Configuration GetServerConfiguration()
+        public virtual Configuration GetServerConfiguration(bool ignoreLocalPrincipal = false)
         {
             Boolean ssl;
             Boolean addConfig;
@@ -264,6 +265,7 @@ namespace Microsoft.Crm.Sdk.Samples
 
             if (addConfig)
             {
+                config.IgnoreLocalPrincipal = ignoreLocalPrincipal;
                 // Get the server address. If no value is entered, default to Microsoft Dynamics
                 // CRM Online in the North American data center.
                 config.ServerAddress = GetServerAddress(out ssl);
@@ -655,7 +657,7 @@ namespace Microsoft.Crm.Sdk.Samples
                     // For OnlineFederation environments, initially try to authenticate with the current UserPrincipalName
                     // for single sign-on scenario.
                     if (config.EndpointType == AuthenticationProviderType.OnlineFederation
-                        && config.AuthFailureCount == 0)
+                        && config.AuthFailureCount == 0 && !config.IgnoreLocalPrincipal)
                     {
                         //Try to get the current UPN, if it fails, ignore the error and don't get the value.
                         //Issue 160 - UPN is not always accessible through UserPrincipal.Current.

--- a/spkl/spkl/Program.cs
+++ b/spkl/spkl/Program.cs
@@ -138,7 +138,7 @@ namespace SparkleXrmTask
                 {
                     // No Connection is supplied to ask for connection on command line 
                     ServerConnection serverConnect = new ServerConnection();
-                    ServerConnection.Configuration config = serverConnect.GetServerConfiguration();
+                    ServerConnection.Configuration config = serverConnect.GetServerConfiguration(arguments.IgnoreLocalPrincipal);
                    
                     arguments.Connection = BuildConnectionString(config);
 

--- a/spkl/spkl/Program.cs
+++ b/spkl/spkl/Program.cs
@@ -170,6 +170,11 @@ namespace SparkleXrmTask
 
                     using (var serviceProxy = new CrmServiceClient(arguments.Connection))
                     {
+                        if (serviceProxy.OrganizationServiceProxy == null)
+                        {
+                            throw new SparkleTaskException(SparkleTaskException.ExceptionTypes.AUTH_ERROR, String.Format("Error connecting to the Organization Service Proxy: {0}", serviceProxy.LastCrmError));
+                        }
+
                         serviceProxy.OrganizationServiceProxy.Timeout = new TimeSpan(1, 0, 0);
                         if (!serviceProxy.IsReady)
                         {


### PR DESCRIPTION
I added a command line flag that allows you to not use your Windows credentials as the credentials for discovery and manually set them. Also fixed an issue where a connection string has a bad password and not catching a NullReferenceException.