### PR TITLE
RollupRequest and Response

### DIFF
--- a/SparkleXrmSource/SparkleXrm/Sdk/Messages/RollupRequest.cs
+++ b/SparkleXrmSource/SparkleXrm/Sdk/Messages/RollupRequest.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Xrm.Sdk.Messages
+{
+    /// <summary>
+    /// Create rollup query
+    /// </summary>
+    [ScriptNamespace("SparkleXrm.Sdk.Messages")]
+    public class RollupRequest : OrganizationRequest
+    {
+        public string Query;
+        public string TargetLogicalName;
+        public string TargetGuid;
+        public string RollupType; // None, Related or Extended
+
+        public string Serialise()
+        {
+            return String.Format("<request i:type=\"b:RollupRequest\" xmlns:a=\"http://schemas.microsoft.com/xrm/2011/Contracts\" xmlns:b=\"http://schemas.microsoft.com/crm/2011/Contracts\">"
+            + "        <a:Parameters xmlns:c=\"http://schemas.datacontract.org/2004/07/System.Collections.Generic\">"
+            + "        <a:KeyValuePairOfstringanyType>"
+            + "            <c:key>Target</c:key>"
+            + "            <c:value i:type=\"a:EntityReference\">"
+            + "              <a:Id>" + TargetGuid + "</a:Id>"
+            + "              <a:LogicalName>" + TargetLogicalName + "</a:LogicalName>"
+            + "              <a:Name i:nil=\"true\" />"
+            + "            </c:value>"
+            + "          </a:KeyValuePairOfstringanyType>"
+            + "        <a:KeyValuePairOfstringanyType>"
+            +           Query
+            + "        </a:KeyValuePairOfstringanyType>"
+            + "        <a:KeyValuePairOfstringanyType>"
+            + "            <c:key>RollupType</c:key>"
+            + "            <c:value i:type=\"b:RollupType\">" + RollupType + "</c:value>"
+            + "          </a:KeyValuePairOfstringanyType>"
+            + "        </a:Parameters>"
+            + "        <a:RequestId i:nil=\"true\" />"
+            + "        <a:RequestName>Rollup</a:RequestName>"
+            + "      </request>");
+        }
+    }
+}

--- a/SparkleXrmSource/SparkleXrm/Sdk/Messages/RollupRequest.cs
+++ b/SparkleXrmSource/SparkleXrm/Sdk/Messages/RollupRequest.cs
@@ -17,26 +17,26 @@ namespace Xrm.Sdk.Messages
         public string Serialise()
         {
             return String.Format("<request i:type=\"b:RollupRequest\" xmlns:a=\"http://schemas.microsoft.com/xrm/2011/Contracts\" xmlns:b=\"http://schemas.microsoft.com/crm/2011/Contracts\">"
-            + "        <a:Parameters xmlns:c=\"http://schemas.datacontract.org/2004/07/System.Collections.Generic\">"
-            + "        <a:KeyValuePairOfstringanyType>"
-            + "            <c:key>Target</c:key>"
-            + "            <c:value i:type=\"a:EntityReference\">"
-            + "              <a:Id>" + TargetGuid + "</a:Id>"
-            + "              <a:LogicalName>" + TargetLogicalName + "</a:LogicalName>"
-            + "              <a:Name i:nil=\"true\" />"
-            + "            </c:value>"
-            + "          </a:KeyValuePairOfstringanyType>"
-            + "        <a:KeyValuePairOfstringanyType>"
-            +           Query
-            + "        </a:KeyValuePairOfstringanyType>"
-            + "        <a:KeyValuePairOfstringanyType>"
-            + "            <c:key>RollupType</c:key>"
-            + "            <c:value i:type=\"b:RollupType\">" + RollupType + "</c:value>"
-            + "          </a:KeyValuePairOfstringanyType>"
-            + "        </a:Parameters>"
-            + "        <a:RequestId i:nil=\"true\" />"
-            + "        <a:RequestName>Rollup</a:RequestName>"
-            + "      </request>");
+            + "<a:Parameters xmlns:c=\"http://schemas.datacontract.org/2004/07/System.Collections.Generic\">"
+            + "<a:KeyValuePairOfstringanyType>"
+            + "<c:key>Target</c:key>"
+            + "<c:value i:type=\"a:EntityReference\">"
+            + "<a:Id>" + TargetGuid + "</a:Id>"
+            + "<a:LogicalName>" + TargetLogicalName + "</a:LogicalName>"
+            + "<a:Name i:nil=\"true\" />"
+            + "</c:value>"
+            + "</a:KeyValuePairOfstringanyType>"
+            + "<a:KeyValuePairOfstringanyType>"
+            + Query
+            + "</a:KeyValuePairOfstringanyType>"
+            + "<a:KeyValuePairOfstringanyType>"
+            + "<c:key>RollupType</c:key>"
+            + "<c:value i:type=\"b:RollupType\">" + RollupType + "</c:value>"
+            + "</a:KeyValuePairOfstringanyType>"
+            + "</a:Parameters>"
+            + "<a:RequestId i:nil=\"true\" />"
+            + "<a:RequestName>Rollup</a:RequestName>"
+            + "</request>");
         }
     }
 }

--- a/SparkleXrmSource/SparkleXrm/Sdk/Messages/RollupResponse.cs
+++ b/SparkleXrmSource/SparkleXrm/Sdk/Messages/RollupResponse.cs
@@ -1,0 +1,28 @@
+using System.Runtime.CompilerServices;
+using System.Xml;
+
+namespace Xrm.Sdk.Messages
+{
+    [ScriptNamespace("SparkleXrm.Sdk.Messages")]
+    public class RollupResponse : OrganizationResponse
+    {
+        public EntityCollection EntityCollection;
+
+        public RollupResponse(XmlNode response)
+        {
+            XmlNode results = XmlHelper.SelectSingleNode(response, "Results");
+
+            foreach (XmlNode nameValuePair in results.ChildNodes)
+            {
+                XmlNode key = XmlHelper.SelectSingleNode(nameValuePair, "key");
+
+                if (XmlHelper.GetNodeTextValue(key) == "EntityCollection")
+                {
+                    XmlNode value = XmlHelper.SelectSingleNode(nameValuePair, "value");
+                    this.EntityCollection = EntityCollection.DeSerialise(value);
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
This allowed me to build an activity grid that behaves exactly like the Social Pane by using the "Extended" RollupType.

Example for a query:
`String allActivitiesQuery = String.Format("<c:key>Query</c:key>"
+ "<c:value i:type=\"a:QueryExpression\">"
+ "<a:ColumnSet>"
+ "<a:AllColumns>false</a:AllColumns>"
+ "<a:Columns xmlns:b=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\">"
+ "<b:string>activityid</b:string>"
+ "<b:string>subject</b:string>"
+ "<b:string>regardingobjectid</b:string>"
+ "<b:string>activitytypecode</b:string>"
+ "<b:string>statecode</b:string>"
+ "<b:string>scheduledstart</b:string>"
+ "<b:string>scheduledend</b:string>"
+ "<b:string>actualend</b:string>"
+ "<b:string>ownerid</b:string>"
+ "<b:string>createdon</b:string>"
+ "</a:Columns>"
+ "</a:ColumnSet>"
+ "<a:Criteria>"
+ "<a:Conditions />"
+ "<a:FilterOperator>And</a:FilterOperator>"
+ "<a:Filters>"
+ "<a:Distinct>false</a:Distinct>"
+ "<a:EntityName>activitypointer</a:EntityName>"
+ "<a:LinkEntities/>"
+ "<a:Orders/>"
+ "<a:PageInfo>"
+ "<a:Count>0</a:Count>"
+ "<a:PageNumber>0</a:PageNumber>"
+ "<a:PagingCookie i:nil=\"true\"/>"
+ "<a:ReturnTotalRecordCount>true</a:ReturnTotalRecordCount>"
+ "</a:PageInfo>"
+ "<a:NoLock>false</a:NoLock>"
+ "</c:value>");`