### PR TITLE
Option to export solution as managed

### DIFF
--- a/spkl/SparkleXrm.Tasks/Tasks/SolutionPackagerTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/SolutionPackagerTask.cs
@@ -252,7 +252,7 @@ namespace SparkleXrm.Tasks
                 ExportOutlookSynchronizationSettings = false,
                 ExportRelationshipRoles = false,
                 ExportSales = false,
-                Managed = false
+                Managed = solutionPackagerConfig.packagetype == PackageType.managed
             };
 
             var response = (ExportSolutionResponse)_service.Execute(request);


### PR DESCRIPTION
This allows me to use the `unpack` command to export and unpack a solution as managed, and then run `import` to pack and import the solution as managed.