### PR TITLE
Fix #226: Predefined Type '' is not defined or imported

### DIFF
--- a/SparkleXrmSamples/SparkleXrmTemplateVS2016DeveloperToolkit365/ClientHooks/ClientHooks.csproj
+++ b/SparkleXrmSamples/SparkleXrmTemplateVS2016DeveloperToolkit365/ClientHooks/ClientHooks.csproj
@@ -18,6 +18,7 @@
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+	<DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\</OutputPath>

--- a/SparkleXrmSamples/SparkleXrmTemplateVS2016DeveloperToolkit365/ClientUI.UnitTests/ClientUI.UnitTests.csproj
+++ b/SparkleXrmSamples/SparkleXrmTemplateVS2016DeveloperToolkit365/ClientUI.UnitTests/ClientUI.UnitTests.csproj
@@ -14,6 +14,7 @@
     <CodeAnalysisRuleSet>Properties\FxCop.ruleset</CodeAnalysisRuleSet>
     <GenerateScript>True</GenerateScript>
     <GenerateResources>True</GenerateResources>
+	<DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\</OutputPath>

--- a/SparkleXrmSamples/SparkleXrmTemplateVS2016DeveloperToolkit365/ClientUI/ClientUI.csproj
+++ b/SparkleXrmSamples/SparkleXrmTemplateVS2016DeveloperToolkit365/ClientUI/ClientUI.csproj
@@ -16,6 +16,7 @@
     <GenerateResources>True</GenerateResources>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+	<DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
Due to Visual Studio 2017 changes in how assemblies are resolved. Now project can be built using Visual Studio 2017
Resolves #226 