### PR TITLE
Spkl Bug fixes

### DIFF
--- a/spkl/SparkleXrm.Tasks/Reflection.cs
+++ b/spkl/SparkleXrm.Tasks/Reflection.cs
@@ -76,6 +76,7 @@ namespace SparkleXrm.Tasks
         {
             AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve += CurrentDomain_ReflectionOnlyAssemblyResolve;
             var types = assembly.DefinedTypes.Where(p => p.GetInterfaces().FirstOrDefault(a => a.Name == interfaceName.Name) != null);
+            Trace.WriteLine(types.FirstOrDefault()?.CustomAttributes.Count());
             AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve -= CurrentDomain_ReflectionOnlyAssemblyResolve;
             return types;
         }


### PR DESCRIPTION

Cannot resolve dependency to assembly 'System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' because it has not been preloaded. When using the ReflectionOnly APIs, dependent assemblies must be pre-loaded or loaded on demand through the ReflectionOnlyAssemblyResolve event. site:stackoverflow.com