### PR TITLE
Added logic to auto-detect files from directory

### DIFF
--- a/spkl/SparkleXrm.Tasks/Config/WebresourceDeployConfig.cs
+++ b/spkl/SparkleXrm.Tasks/Config/WebresourceDeployConfig.cs
@@ -11,7 +11,8 @@ namespace SparkleXrm.Tasks.Config
         public string profile;
         public string root;
         public string solution;
+        public string autodetect;
+        public string deleteaction;
         public List<WebResourceFile> files;
     }
-
 }

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployWebResourcesTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployWebResourcesTask.cs
@@ -34,8 +34,8 @@ namespace SparkleXrm.Tasks
                 }
                 foreach (var webresources in configSections)
                 {
-                    var ids = DeployWebresources(ctx, config, webresources);
-                    _trace.WriteLine("Publishing {0} webresources...", webresources.files.Count);
+                    List<Guid> ids = DeployWebresources(ctx, config, webresources);
+                    _trace.WriteLine("Publishing {0} webresources...", ids.Count);
                     PublishWebresources(ids);
                     _trace.WriteLine("Publish complete.");
                 }
@@ -45,109 +45,235 @@ namespace SparkleXrm.Tasks
             _trace.WriteLine("Processed {0} config(s)", configs.Count);
         }
 
-        public IEnumerable<Guid> DeployWebresources(OrganizationServiceContext ctx, ConfigFile config, WebresourceDeployConfig webresources)
+        public List<Guid> DeployWebresources(OrganizationServiceContext ctx, ConfigFile config, WebresourceDeployConfig webresources)
         {
             var webresourceRoot = Path.Combine(config.filePath, "" + webresources.root);
 
             this.Solution = webresources.solution;
 
-            var webresourcesToPublish = new List<Guid>(webresources.files.Count);
-
-            foreach (var file in webresources.files)
+            bool autodetect = false;
+            if (webresources.autodetect != null)
             {
-                if (file.uniquename == null)
+                switch (webresources.autodetect.ToLower())
                 {
-                    // Make the name uniquename the same as the file name
-                    file.uniquename = file.file.Replace("\\", "/");
+                    case "yes":
+                    case "true":
+                        autodetect = true;
+                        break;
+                    case "no":
+                    case "false":
+                        autodetect = false;
+                        break;
+                    default:
+                        _trace.WriteLine("Invalid autodetect setting found: " + webresources.autodetect);
+                        return null;
                 }
-                if (file.displayname == null)
-                {
-                    // make the same as the unique name
-                    file.displayname = file.uniquename;
-                }
-                WebResource webresource = ServiceLocator.Queries.GetWebResource(ctx, file.uniquename);
-
-                if (webresource == null)
-                    webresource = new WebResource();
-                var fullPath = Path.Combine(webresourceRoot, file.file);
-                var filecontent = Convert.ToBase64String(File.ReadAllBytes(fullPath));
-
-                // Update
-                webresource.Name = file.uniquename;
-                webresource.DisplayName = file.displayname;
-                webresource.Description = file.description;
-                webresource.Content = filecontent;
-
-                var webResourceFileInfo = new FileInfo(fullPath);
-                webresource_webresourcetype filetype = webresource_webresourcetype.Script_JScript;
-                switch (webResourceFileInfo.Extension.ToLower().TrimStart('.'))
-                {
-                    case "html":
-                    case "htm":
-                        filetype = webresource_webresourcetype.Webpage_HTML;
-                        break;
-                    case "js":
-                        filetype = webresource_webresourcetype.Script_JScript;
-                        break;
-                    case "png":
-                        filetype = webresource_webresourcetype.PNGformat;
-                        break;
-                    case "gif":
-                        filetype = webresource_webresourcetype.GIFformat;
-                        break;
-                    case "jpg":
-                    case "jpeg":
-                        filetype = webresource_webresourcetype.JPGformat;
-                        break;
-                    case "css":
-                        filetype = webresource_webresourcetype.StyleSheet_CSS;
-                        break;
-                    case "ico":
-                        filetype = webresource_webresourcetype.ICOformat;
-                        break;
-                    case "xml":
-                        filetype = webresource_webresourcetype.Data_XML;
-                        break;
-                    case "xsl":
-                    case "xslt":
-                        filetype = webresource_webresourcetype.StyleSheet_XSL;
-                        break;
-                    case "xap":
-                        filetype = webresource_webresourcetype.Silverlight_XAP;
-                        break;
-                    case "svg":
-                        filetype = webresource_webresourcetype.Vectorformat_SVG;
-                        break;
-                }
-                webresource.WebResourceType = filetype;
-                if (webresource.Id == Guid.Empty)
-                {
-                    _trace.WriteLine("Creating Webresource '{0}' -> '{1}'", file.file, file.uniquename);
-                    // create
-                    webresource.Id = _service.Create(webresource);
-                }
-                else
-                {
-                    _trace.WriteLine("Updating Webresource '{0}' -> '{1}'", file.file, file.uniquename);
-                    // Update
-                    _service.Update(webresource);
-                }
-                ;
-
-                // Add to solution
-                if (Solution != null)
-                {
-                    AddWebresourceToSolution(Solution, webresource);
-                }
-
-                webresourcesToPublish.Add(webresource.Id);
             }
-            _trace.WriteLine("Deployed {0} webresource(s)", webresources.files.Count);
+            var webresourcesToPublish = new List<Guid>();
 
+            if (autodetect)
+            {
+                AutoDetect(ctx, webresourceRoot, webresources, webresourcesToPublish);
+            }
+            else
+            {
+                foreach (var file in webresources.files)
+                {
+                    DeployWebResource(ctx, webresourceRoot, webresourcesToPublish, file);
+                }
+            }
+            _trace.WriteLine("Deployed {0} webresource(s)", webresourcesToPublish.Count);
             return webresourcesToPublish;
         }
 
-        
+        private void AutoDetect(OrganizationServiceContext ctx, string webresourceRoot, WebresourceDeployConfig webresources, List<Guid> webresourcesToPublish)
+        {
+            if (Solution == null)
+            {
+                _trace.WriteLine("Solution Name required for AutoDetect");
+                return;
+            }
+            if (webresources.deleteaction != null)
+            {
+                switch (webresources.deleteaction.ToLower())
+                {
+                    case "delete":
+                        webresources.deleteaction = webresources.deleteaction.ToLower();
+                        break;
+                    case "remove":
+                        webresources.deleteaction = webresources.deleteaction.ToLower();
+                        break;
+                    case "no":
+                    case "leave":
+                    case "nothing":
+                        webresources.deleteaction = "no";
+                        break;
+                    default:
+                        _trace.WriteLine("Invalid deleteaction: " + webresources.deleteaction);
+                        return;
+                }
+            }
+            else
+            {
+                webresources.deleteaction = "no";
+            }
+            if (!Directory.Exists(webresourceRoot))
+            {
+                _trace.WriteLine("WebResource source Folder not found: " + webresourceRoot);
+                return;
+            }
+
+            // Get existing solution WRs
+            List<WebResource> curWebResources = ServiceLocator.Queries.GetWebresourcesInSolution(ctx, this.Solution);
+            _trace.WriteLine(string.Format("{0} Current WebResourceCount: {1}", this.Solution, curWebResources.Count));
+
+            DeployDirectory(ctx, webresourceRoot, webresourceRoot, webresourcesToPublish, curWebResources);
+            _trace.WriteLine(string.Format("{0} WebResources no longer present in directory", curWebResources.Count));
+
+            if (webresources.deleteaction == "delete" || webresources.deleteaction == "remove")
+            {
+                foreach (var curWebResource in curWebResources)
+                {
+                    if (webresources.deleteaction == "delete")
+                    {
+                        _trace.WriteLine(string.Format("Deleting '{0}'", curWebResource.Name));
+                        _service.Delete(WebResource.EntityLogicalName, curWebResource.Id);
+                    }
+                    else
+                    {
+                        _trace.WriteLine(string.Format("Remove from solution '{0}'", curWebResource.Name));
+                        RemoveWebresourceFromSolution(this.Solution, curWebResource);
+                    }
+                }
+            }
+        }
+
+        private void DeployDirectory(OrganizationServiceContext ctx, string webresourceRoot, string directory, List<Guid> webresourcesToPublish, List<WebResource> curWebResources)
+        {
+            //_trace.WriteLine("DeployDirectory: " + directory);
+            var webResSplit = webresourceRoot.Replace('/', '\\').Split('\\');
+
+            var fullPath = Path.Combine(webresourceRoot, directory);
+
+            string[] fileEntries = Directory.GetFiles(directory);
+            foreach (string fileName in fileEntries)
+            {
+                // Strip WebResource root from the filename
+                string relativePathFileName = string.Join("\\", fileName.Split('\\').Skip(webResSplit.Count()));
+                WebResourceFile file = new WebResourceFile
+                {
+                    file = relativePathFileName
+                };
+                DeployWebResource(ctx, webresourceRoot, webresourcesToPublish, file);
+
+                WebResource webResourceListItem = curWebResources.FirstOrDefault(wr => wr.Name == relativePathFileName.Replace("\\", "/"));
+                if (webResourceListItem != null)
+                {
+                    curWebResources.Remove(webResourceListItem);
+                }
+            }
+
+            // Recurse into subdirectories of this directory.
+            string[] subdirectoryEntries = Directory.GetDirectories(directory);
+            foreach (string subdirectory in subdirectoryEntries)
+            {
+                DeployDirectory(ctx, webresourceRoot, subdirectory, webresourcesToPublish, curWebResources);
+            }
+        }
+
+        private void DeployWebResource(OrganizationServiceContext ctx, string webresourceRoot, List<Guid> webresourcesToPublish, WebResourceFile file)
+        {
+            if (file.uniquename == null)
+            {
+                // Make the name uniquename the same as the file name
+                file.uniquename = file.file.Replace("\\", "/");
+            }
+            if (file.displayname == null)
+            {
+                // make the same as the unique name
+                file.displayname = file.uniquename;
+            }
+            WebResource webresource = ServiceLocator.Queries.GetWebResource(ctx, file.uniquename);
+
+            if (webresource == null)
+            {
+                webresource = new WebResource();
+            }
+            var fullPath = Path.Combine(webresourceRoot, file.file);
+            var filecontent = Convert.ToBase64String(File.ReadAllBytes(fullPath));
+
+            // Update
+            webresource.Name = file.uniquename;
+            webresource.DisplayName = file.displayname;
+            webresource.Description = file.description;
+            webresource.Content = filecontent;
+
+            var webResourceFileInfo = new FileInfo(fullPath);
+            webresource_webresourcetype filetype = webresource_webresourcetype.Script_JScript;
+            switch (webResourceFileInfo.Extension.ToLower().TrimStart('.'))
+            {
+                case "html":
+                case "htm":
+                    filetype = webresource_webresourcetype.Webpage_HTML;
+                    break;
+                case "js":
+                    filetype = webresource_webresourcetype.Script_JScript;
+                    break;
+                case "png":
+                    filetype = webresource_webresourcetype.PNGformat;
+                    break;
+                case "gif":
+                    filetype = webresource_webresourcetype.GIFformat;
+                    break;
+                case "jpg":
+                case "jpeg":
+                    filetype = webresource_webresourcetype.JPGformat;
+                    break;
+                case "css":
+                    filetype = webresource_webresourcetype.StyleSheet_CSS;
+                    break;
+                case "ico":
+                    filetype = webresource_webresourcetype.ICOformat;
+                    break;
+                case "xml":
+                    filetype = webresource_webresourcetype.Data_XML;
+                    break;
+                case "xsl":
+                case "xslt":
+                    filetype = webresource_webresourcetype.StyleSheet_XSL;
+                    break;
+                case "xap":
+                    filetype = webresource_webresourcetype.Silverlight_XAP;
+                    break;
+                case "svg":
+                    filetype = webresource_webresourcetype.Vectorformat_SVG;
+                    break;
+                default:
+                    _trace.WriteLine("File extension '{0}' unexpected -> '{1}'", webResourceFileInfo.Extension, file.file);
+                    return;
+            }
+            webresource.WebResourceType = filetype;
+            if (webresource.Id == Guid.Empty)
+            {
+                _trace.WriteLine("Creating Webresource '{0}' -> '{1}'", file.file, file.uniquename);
+                // Create
+                webresource.Id = _service.Create(webresource);
+            }
+            else
+            {
+                _trace.WriteLine("Updating Webresource '{0}' -> '{1}'", file.file, file.uniquename);
+                // Update
+                _service.Update(webresource);
+            }
+
+            // Add to solution
+            if (Solution != null)
+            {
+                AddWebresourceToSolution(Solution, webresource);
+            }
+
+            webresourcesToPublish.Add(webresource.Id);
+        }
 
         private void AddWebresourceToSolution(string solutionName, WebResource webresource)
         {
@@ -163,7 +289,18 @@ namespace SparkleXrm.Tasks
             _service.Execute(addToSolution);
         }
 
-
+        private void RemoveWebresourceFromSolution(string solutionName, WebResource webresource)
+        {
+            // Find solution
+            RemoveSolutionComponentRequest removeFromSolution = new RemoveSolutionComponentRequest()
+            {
+                ComponentType = (int)componenttype.WebResource,
+                ComponentId = webresource.Id,
+                SolutionUniqueName = solutionName
+            };
+            _trace.WriteLine(string.Format("Solution: '{0}' Removing: '{1}'", solutionName, webresource.Name));
+            _service.Execute(removeFromSolution);
+        }
 
         public void PublishWebresources(IEnumerable<Guid> guids)
         {

--- a/spkl/SparkleXrm.Tasks/Tasks/Queries.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/Queries.cs
@@ -183,6 +183,7 @@ namespace SparkleXrm.Tasks
                     select new WebResource
                     {
                         Name = w.Name,
+                        WebResourceId = w.WebResourceId,
                         DisplayName = w.DisplayName,
                         Description = w.Description,
                         Content = w.Content,

--- a/spkl/spkl/Package/spkl.json
+++ b/spkl/spkl/Package/spkl.json
@@ -1,32 +1,43 @@
 {
     "webresources": [
-        {
-            /* 
-            Option - profile - Provide a comma delimitered list of profile names that can be referenced when calling spkl
-            */
-            "profile": "default,debug",
+      {
+          /* 
+          Option - profile - Provide a comma delimitered list of profile names that can be referenced when calling spkl
+          */
+          "profile": "default,debug",
 
-            /*
-            Optional - root - Provide the relatative path of the webresources.
-            */
-            "root": "Webresources/",
+          /*
+          Optional - root - Provide the relatative path of the webresources.
+          */
+          "root": "Webresources/",
 
-            /*
-            Optional - solution - Add webresources to a solution when deploying
-            */
-            "solution": "<SolutionUniqueName>",
+          /*
+          Optional - solution - Add webresources to a solution when deploying
+          */
+          "solution": "<SolutionUniqueName>",
 
-            /*
-            Required - files - List the webresources to deploy relatative to the root of this file (or the the root parameter above)
-            */
-            "files": [
-                {
-                    "uniquename": "new_/js/somefile.js",
-                    "file": "new_\\js\\somefile.js",
-                    "description": ""
-                }
-            ]
-        }
+          /*
+          Optional - autodetect - Process all files from the root directory
+          "autodetect": "no|yes",
+          */
+
+          /*
+          Optional - deleteaction - Whether or not Web Resources in the Solution no longer present in folder tree should be Deleted or Removed from the solution.
+          "deleteaction": "no|delete|remove",
+          */
+
+          /*
+          Required - files - List the webresources to deploy relatative to the root of this file (or the the root parameter above)
+          Optional when autodetect=yes
+          */ 
+          "files": [
+          {
+            "uniquename": "new_/js/somefile.js",
+            "file": "new_\\js\\somefile.js",
+            "description": ""
+          }
+        ]
+      }
     ],
     "plugins": [
         {


### PR DESCRIPTION
I added logic to deploy-webresource that allows the folder tree of the source to drive the process instead of requiring individual file entriies in spkl.json. Also included the ability to Delete or Remove web resources in the Solution that are no longer in the derectory tree. As an example, spkl.json can be the following:

  "webresources": [
    {
      "root": "sourcefolder",
      "solution": "Test",
      "autodetect": "yes",
      "deleteaction": "delete"
    }
  ]
