### PR TITLE
Fix 263 - Allow underscore when Regex matching classes for earlybound…

### DIFF
--- a/spkl/SparkleXrm.Tasks/CrmSvcUtil/SourceCodeTypeExtractor.cs
+++ b/spkl/SparkleXrm.Tasks/CrmSvcUtil/SourceCodeTypeExtractor.cs
@@ -6,11 +6,11 @@
 
     public class SourceCodeTypeExtractor
     {
-        private const string ClassPattern = @"([a-zA-Z0-9\(\"",\s\.\)\]\s\n\[:])+public\spartial[a-zA-Z0-9\s:\.,_]+{(?:[^{}]|(?<open>{)|(?<-open>}))+(?(open)(?!))}";
+        private const string ClassPattern = @"([a-zA-Z0-9\(\"",\s\.\)\]\s\n\[:_])+public\spartial[a-zA-Z0-9\s:\.,_]+{(?:[^{}]|(?<open>{)|(?<-open>}))+(?(open)(?!))}";
         private const string EnumPattern = @"([a-zA-Z0-9\(\"",\s\.\)\]\s\n\[:])+public\senum[a-zA-Z0-9\s_]+{(?:[^{}]|(?<open>{)|(?<-open>}))+(?(open)(?!))}";
 
         public List<TypeContainer> ExtractTypes(string input)
-        {  
+        {
             var classMatches = new Regex(ClassPattern).Matches(input);
             var result = (from Match match in classMatches
                           select new TypeContainer(ContainerType.ClassContainer, match.Value))


### PR DESCRIPTION
Earlybound classes are incorrectly split, resulting in malformed classes. Issue affects entities with "underscore" in the logical name. Added underscore to class regex.