### PR TITLE
Assembly load redirect for Microsoft.Crm.Sdk.Proxy

### DIFF
--- a/spkl/SparkleXrm.Tasks/Reflection.cs
+++ b/spkl/SparkleXrm.Tasks/Reflection.cs
@@ -64,6 +64,9 @@ namespace SparkleXrm.Tasks
                 case "Microsoft.Xrm.Sdk":
                     assembly = System.Reflection.Assembly.ReflectionOnlyLoad(parts[0].Trim());
                     break;
+                case "Microsoft.Crm.Sdk.Proxy":
+                    assembly = System.Reflection.Assembly.ReflectionOnlyLoad(parts[0].Trim());
+                    break;
                 default:
                     assembly = System.Reflection.Assembly.ReflectionOnlyLoad(args.Name);
                     break;


### PR DESCRIPTION
Resolution for #237 

Spkl now redirects loading of Microsoft.Crm.Sdk.Proxy to compiled version (9.0) rather than attempting to load dependent version from plugin/workflow assembly (i.e. 8.x).

Tested deployment of workflow assembly:

Built against Microsoft.Crm.Sdk.Proxy 8.2.0.2 and deployed to CRM 8.2.2.2114
Built against Microsoft.Crm.Sdk.Proxy 9.0.2.4 and deployed to CRM 9.0.2.758

NOTE: This is a duplicate new PR to replace #262. This PR is from my working branch rather than spkl_dev and only includes one commit