### PR TITLE
Retain Assembly file encoding

### DIFF
--- a/spkl/SparkleXrm.Tasks/CodeParser.cs
+++ b/spkl/SparkleXrm.Tasks/CodeParser.cs
@@ -16,6 +16,7 @@ namespace SparkleXrm.Tasks
         #region Private Fields
         private string _filePath;
         private string _code;
+        private Encoding _encoding;
         private Dictionary<string,Match> _pluginClasses;
         private Dictionary<string, Match> _pluginTypes;
         private Dictionary<string, Match> _workflowTypes;
@@ -36,6 +37,19 @@ namespace SparkleXrm.Tasks
         {
             _filePath = filePath.OriginalString;
             _code = File.ReadAllText(_filePath);
+
+            // Get current encoding of the file
+            // Need to read part of the file to get the current encoding
+            using (var reader = new StreamReader(_filePath, Encoding.Default, true))
+            {
+                if (reader.Peek() >= 0)
+                {
+                    reader.Read();
+                }
+
+                _encoding = reader.CurrentEncoding;
+            }
+
             if (customClassRegex != null)
                 ClassRegex = customClassRegex;
 
@@ -97,6 +111,10 @@ namespace SparkleXrm.Tasks
             get { return _code; }
         }
 
+        public Encoding CurEncoding
+        {
+            get { return _encoding; }
+        }
         public string FilePath
         {
             get { return _filePath; }

--- a/spkl/SparkleXrm.Tasks/Tasks/DownloadPluginMetadataTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DownloadPluginMetadataTask.cs
@@ -53,7 +53,7 @@ namespace SparkleXrm.Tasks
                     if (parser.PluginCount > 0)
                     {
                         // Backup 
-                        File.WriteAllText(parser.FilePath + DateTime.Now.ToString("yyyyMMddHHmmss") + ".bak", parser.Code);
+                        File.WriteAllText(parser.FilePath + DateTime.Now.ToString("yyyyMMddHHmmss") + ".bak", parser.Code, parser.CurEncoding);
                         foreach (var pluginType in parser.ClassNames)
                         {
                             // Remove existing attributes
@@ -73,7 +73,7 @@ namespace SparkleXrm.Tasks
                             }
                         }
                         // Update 
-                        File.WriteAllText(parser.FilePath, parser.Code);
+                        File.WriteAllText(parser.FilePath, parser.Code, parser.CurEncoding);
                         codeFilesUpdated++;
                     }
                 }


### PR DESCRIPTION
Fix for issue #233. Detects the current file encoding and uses that when writing the files.