### PR TITLE
Support "EmailId" message property name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ To build the source you will need to install:
 * VS2012
 * [Developer Toolkit for VS2012](http://msdn.microsoft.com/en-us/library/hh372957.aspx)
 * Script# v0.7.5 (Install through Tools->Extensions & Updates)
+* PowerShell Tools for Visual Studio 2012 v1.0.5 (Install through Tools->Extensions & Updates)
 
 The DebugWeb project allows you to run and debug the samples without publishing to CRM. The [standalone samples](http://www.sparklexrm.com/s/Tutorials/SetUpNewProject.html) projects use fiddler to allow debugging, but I found having a dedicated test web easier for the full source.
 

--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -528,6 +528,11 @@ namespace SparkleXrm.Tasks
                 case "SetStateDynamicEntity":
                     image.MessagePropertyName = "EntityMoniker";
                     break;
+                case "Send":
+                case "DeliverIncoming":
+                case "DeliverPromote":
+                    image.MessagePropertyName = "EmailId";
+                    break;
                 default:
                     image.MessagePropertyName = "Target";
                     break;


### PR DESCRIPTION
Added support for the `EmailId` MessagePropertyName.

This resolves issue  #285 where an error is thrown when deploying an image for a plugin step registered against the `Send`, `DeliverIncoming `or `DeliverPromote` messages.

