### PR TITLE
Added argument to exclude plugin steps from plugin deployment

### DIFF
--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -168,7 +168,7 @@ namespace SparkleXrm.Tasks
         }
 
 
-        public void RegisterPlugin(string file)
+        public void RegisterPlugin(string file, bool excludePluginSteps = false)
         {
             var assemblyFilePath = new FileInfo(file);
 
@@ -192,6 +192,7 @@ namespace SparkleXrm.Tasks
                 var plugin = RegisterAssembly(assemblyFilePath, peekAssembly, pluginTypes);
 
                 if (plugin != null)
+                if (plugin != null && !excludePluginSteps)
                 {
                     RegisterPluginSteps(pluginTypes, plugin);
                 }

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsTask.cs
@@ -14,6 +14,8 @@ namespace SparkleXrm.Tasks
 {
     public class DeployPluginsTask : BaseTask
     {
+        public bool ExcludePluginSteps { get; set; }
+
         public DeployPluginsTask(IOrganizationService service, ITrace trace) : base(service, trace)
         {
           
@@ -55,7 +57,7 @@ namespace SparkleXrm.Tasks
                 {
                     try
                     {
-                        pluginRegistration.RegisterPlugin(assemblyFilePath);
+                        pluginRegistration.RegisterPlugin(assemblyFilePath, ExcludePluginSteps);
                     }
 
                     catch (ReflectionTypeLoadException ex)

--- a/spkl/spkl/CommandLineArgs.cs
+++ b/spkl/spkl/CommandLineArgs.cs
@@ -49,5 +49,8 @@ import = Packs a solution as per the 'pack' task, and then imports into Dynamics
 
         [CommandLineParameter(Name = "Ignore Windows login", Command = "i", Required = false, Description = "Optional flag to ignore logged in windows credentials during discovery and always ask for username/password.")]
         public bool IgnoreLocalPrincipal { get; set; }
+
+        [CommandLineParameter(Name = "Exclude Plugin Steps", Command = "e", Required = false, Description = "Exclude plugin steps when deploying plugins")]
+        public bool ExcludePluginSteps { get; set; }
     }
 }

--- a/spkl/spkl/Program.cs
+++ b/spkl/spkl/Program.cs
@@ -298,7 +298,8 @@ namespace SparkleXrmTask
             {
                 case "plugins":
                     trace.WriteLine("Deploying Plugins");
-                    task = new DeployPluginsTask(service, trace);
+                    task = new DeployPluginsTask(service, trace)
+                    { ExcludePluginSteps = arguments.ExcludePluginSteps };
                     break;
 
                 case "workflow":


### PR DESCRIPTION
Added the `/e` command line argument that excludes plugin steps from the plugin deployment. 

A useful time saver when deploying large assemblies and no updates to the plugin steps are required.