### PR TITLE
Let OOB scripts to pass parameters to spkl.exe

### DIFF
--- a/spkl/spkl/Package/spkl/deploy-plugins.bat
+++ b/spkl/spkl/Package/spkl/deploy-plugins.bat
@@ -9,6 +9,6 @@ For /R %package_root% %%G IN (spkl.exe) do (
 :continue
 @echo Using '%spkl_path%' 
 REM spkl plugins [path] [connection-string] [/p:release]
-"%spkl_path%" plugins "%cd%\.."
+"%spkl_path%" plugins "%cd%\.." %*
 
 pause

--- a/spkl/spkl/Package/spkl/deploy-webresources.bat
+++ b/spkl/spkl/Package/spkl/deploy-webresources.bat
@@ -9,6 +9,6 @@ For /R %package_root% %%G IN (spkl.exe) do (
 :continue
 @echo Using '%spkl_path%' 
 REM spkl webresources [path] [connection-string]
-"%spkl_path%" webresources "%cd%\.."
+"%spkl_path%" webresources "%cd%\.." %*
 
 pause

--- a/spkl/spkl/Package/spkl/deploy-workflows.bat
+++ b/spkl/spkl/Package/spkl/deploy-workflows.bat
@@ -9,6 +9,6 @@ For /R %package_root% %%G IN (spkl.exe) do (
 :continue
 @echo Using '%spkl_path%' 
 REM spkl workflow [path] [connection-string] [/p:release]
-"%spkl_path%" workflow "%cd%\.."
+"%spkl_path%" workflow "%cd%\.." %*
 
 pause

--- a/spkl/spkl/Package/spkl/download-webresources.bat
+++ b/spkl/spkl/Package/spkl/download-webresources.bat
@@ -9,6 +9,6 @@ For /R %package_root% %%G IN (spkl.exe) do (
 :continue
 @echo Using '%spkl_path%' 
 REM spkl instrument [path] [connection-string] [/p:release]
-"%spkl_path%" download-webresources "%cd%\.." /o
+"%spkl_path%" download-webresources "%cd%\.." /o %*
 
 pause

--- a/spkl/spkl/Package/spkl/earlybound.bat
+++ b/spkl/spkl/Package/spkl/earlybound.bat
@@ -9,6 +9,6 @@ For /R %package_root% %%G IN (spkl.exe) do (
 :continue
 @echo Using '%spkl_path%' 
 REM spkl earlybound [path] [connection-string] [/p:release]
-"%spkl_path%" earlybound "%cd%\.."
+"%spkl_path%" earlybound "%cd%\.." %*
 
 pause

--- a/spkl/spkl/Package/spkl/instrument-plugin-code.bat
+++ b/spkl/spkl/Package/spkl/instrument-plugin-code.bat
@@ -9,6 +9,6 @@ For /R %package_root% %%G IN (spkl.exe) do (
 :continue
 @echo Using '%spkl_path%' 
 REM spkl instrument [path] [connection-string] [/p:release]
-"%spkl_path%" instrument "%cd%\.."
+"%spkl_path%" instrument "%cd%\.." %*
 
 pause

--- a/spkl/spkl/Package/spkl/pack+import.bat
+++ b/spkl/spkl/Package/spkl/pack+import.bat
@@ -9,6 +9,6 @@ For /R %package_root% %%G IN (spkl.exe) do (
 :continue
 @echo Using '%spkl_path%' 
 REM spkl instrument [path] [connection-string] [/p:release]
-"%spkl_path%" import "%cd%\.."
+"%spkl_path%" import "%cd%\.." %*
 
 pause

--- a/spkl/spkl/Package/spkl/unpack.bat
+++ b/spkl/spkl/Package/spkl/unpack.bat
@@ -9,6 +9,6 @@ For /R %package_root% %%G IN (spkl.exe) do (
 :continue
 @echo Using '%spkl_path%' 
 REM spkl instrument [path] [connection-string] [/p:release]
-"%spkl_path%" unpack "%cd%\.."
+"%spkl_path%" unpack "%cd%\.." %*
 
 pause

--- a/spkl/spkl/Package/spkl/unpacksolution.bat
+++ b/spkl/spkl/Package/spkl/unpacksolution.bat
@@ -9,6 +9,6 @@ For /R %package_root% %%G IN (spkl.exe) do (
 :continue
 @echo Using '%spkl_path%' 
 REM spkl instrument [path] [connection-string] [/p:release]
-"%spkl_path%" unpacksolution "%cd%\.." ""
+"%spkl_path%" unpacksolution "%cd%\.." "" %*
 
 pause


### PR DESCRIPTION
This small fix let user the ability to execute OOB scripts like "deploy-webresources.bat" with parameters like "/p:"