### PR TITLE
Fix for: Spkl writes connection string password to log file as a plain text when creating early bound types

### DIFF
--- a/spkl/SparkleXrm.Tasks/Tasks/EarlyBoundClassGeneratorTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/EarlyBoundClassGeneratorTask.cs
@@ -225,21 +225,23 @@ namespace SparkleXrm.Tasks
                                                                       .ToUpperInvariant(),
                                                             str => str.Split('=')
                                                                       .ElementAtOrDefault(1));
-            var passwsLength = connStrParts["PASSWORD"].Length;
 
-            // Magic number nine is lenght of "Password=".
-            var startOfThePassword = indexOfConnStr + indexOfPwOnConnStr + 9;
+            var passwdKey = connStrParts.Keys.Single(key => key.StartsWith("PASSWORD"));
 
-            var charsAfterPassword = logMessage.Length - startOfThePassword - passwsLength;
+            var passwdLength = connStrParts[passwdKey].Length;
 
-            var sb = new StringBuilder(logMessage, 0, startOfThePassword, logMessage.Length);
+            // +1 to take '=' into account.
+            var startOfThePassword = indexOfConnStr + indexOfPwOnConnStr + 1 + passwdKey.Length;
+
+            var charsAfterPassword = logMessage.Length - startOfThePassword - passwdLength;
+
+            var sb = new StringBuilder(logMessage, 0, startOfThePassword,
+                                       logMessage.Length);
             sb.Append("****");
-            sb.Append(logMessage, startOfThePassword + passwsLength, charsAfterPassword);
+            sb.Append(logMessage, startOfThePassword + passwdLength,
+                      charsAfterPassword);
 
             return sb.ToString();
-            
-
-            throw new NotImplementedException();
         }
     }
 }

--- a/spkl/SparkleXrm.Tasks/Tasks/EarlyBoundClassGeneratorTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/EarlyBoundClassGeneratorTask.cs
@@ -226,14 +226,17 @@ namespace SparkleXrm.Tasks
                                                             str => str.Split('=')
                                                                       .ElementAtOrDefault(1));
 
-            var passwdKey = connStrParts.Keys.Single(key => key.StartsWith("PASSWORD"));
+            var passwdKey = connStrParts.Keys
+                                        .Single(key => key.StartsWith("PASSWORD"));
 
             var passwdLength = connStrParts[passwdKey].Length;
 
             // +1 to take '=' into account.
-            var startOfThePassword = indexOfConnStr + indexOfPwOnConnStr + 1 + passwdKey.Length;
+            var startOfThePassword = indexOfConnStr + indexOfPwOnConnStr +
+                                     passwdKey.Length + 1;
 
-            var charsAfterPassword = logMessage.Length - startOfThePassword - passwdLength;
+            var charsAfterPassword = logMessage.Length - startOfThePassword -
+                                     passwdLength;
 
             var sb = new StringBuilder(logMessage, 0, startOfThePassword,
                                        logMessage.Length);


### PR DESCRIPTION
When spkl is used to generate early bound types spkl writes parameters given to CrmSvcUtil into log file. These parameters include connection string and in many cases this will include password. This happens also when spkl interactively asks connection string or password from user.

This PR adds masking functionality into task responsible of creating early bound classes. Call to this masking functionality is added to the point in code which writes parameters into log. Passcode is masked with four stars. Otherwise parameter string going to log is left intact.