### PR TITLE
New spkl task to register plugin steps and custom workflow activities from same assembly

### DIFF
--- a/spkl/SparkleXrm.Tasks/CrmPluginRegistrationAttribute.cs
+++ b/spkl/SparkleXrm.Tasks/CrmPluginRegistrationAttribute.cs
@@ -63,12 +63,30 @@ public class CrmPluginRegistrationAttribute : Attribute
     }
 
     /// <summary>
-    /// Create workflow activity registration
+    /// Create workflow activity registration. Plugin registrations have
+    /// different constructor.
     /// </summary>
-    /// <param name="name">Name of the Workflow Activity</param>
-    /// <param name="friendlyName">Friendly name</param>
-    /// <param name="description">Description</param>
-    /// <param name="groupName">Group Name</param>
+    /// <param name="name">
+    /// Name of the Workflow Activity as presented on workflow designer manu.
+    /// </param>
+    /// <param name="friendlyName">
+    /// User friendly name for the plug-in. This doesn't have to be guid.
+    /// </param>
+    /// <param name="description">
+    /// Not visible in the UI of the process designer, but may be useful when
+    /// generating documentation from data drawn from the PluginType Entity
+    /// that stores this information.
+    /// </param>
+    /// <param name="groupName">
+    /// The name of the submenu added to the main menu in the Common Data
+    /// Service process designer.
+    /// </param>
+    /// <param name="isolationModel">
+    /// Defines isolation mode.
+    /// </param>
+    /// <remarks>
+    /// https://docs.microsoft.com/en-us/powerapps/developer/common-data-service/workflow/workflow-extensions#register-your-assembly
+    /// </remarks>
     public CrmPluginRegistrationAttribute(
         string name,
         string friendlyName,

--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -53,7 +53,7 @@ namespace SparkleXrm.Tasks
 
             AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve += (sender, args) => Assembly.ReflectionOnlyLoad(args.Name);
 
-            // Search for any types that interhit from IPlugin                  
+            // Search for any types that interhit from CodeActivity
             var pluginTypes = GetTypesInheritingFromCodeActivity(peekAssembly);
 
             if (pluginTypes.Count() > 0)
@@ -197,6 +197,20 @@ namespace SparkleXrm.Tasks
 
         }
 
+        /// <summary>
+        /// Registers both plugins and workflow activites declared on assembly
+        /// on specified <paramref name="file"/>.
+        /// </summary>
+        /// <param name="file">
+        /// Path to assembly file.
+        /// </param>
+        /// <param name="excludePluginSteps">
+        /// If true plugin steps aren't registered. At that case this method
+        /// effectively works just like
+        /// <see cref="RegisterActivities(IEnumerable{Type}, PluginAssembly)"/>
+        /// would behave.
+        /// </param>
+        /// <seealso cref="RegisterPluginAndWorkflow(string)"/>
         public void RegisterPluginAndWorkflow(string file,
                                               bool excludePluginSteps = false)
         {
@@ -214,25 +228,27 @@ namespace SparkleXrm.Tasks
             var workflowTypes = GetTypesInheritingFromCodeActivity(peekAssembly);
 
             var typesToRegister = pluginTypes.Union(workflowTypes);
-            if (typesToRegister.Any())
+            if (!typesToRegister.Any())
             {
-                _trace.WriteLine("{0} plugin(s) and {1} workflow activities found!",
-                                 pluginTypes.Count(),
-                                 workflowTypes.Count());
-
-                var pluginAssembly = RegisterAssembly(assemblyFilePath,
-                                                      peekAssembly,
-                                                      typesToRegister);
-
-                if (pluginAssembly == null) {
-                    return;
-                }
-                if(!excludePluginSteps)
-                {
-                    RegisterPluginSteps(pluginTypes, pluginAssembly);
-                }
-                RegisterActivities(workflowTypes, pluginAssembly);
+                return;
             }
+
+            _trace.WriteLine("{0} plugin(s) and {1} workflow activities found!",
+                              pluginTypes.Count(),
+                              workflowTypes.Count());
+
+            var pluginAssembly = RegisterAssembly(assemblyFilePath,
+                                                  peekAssembly,
+                                                  typesToRegister);
+
+            if (pluginAssembly == null) {
+                return;
+            }
+            if(!excludePluginSteps)
+            {
+                RegisterPluginSteps(pluginTypes, pluginAssembly);
+            }
+            RegisterActivities(workflowTypes, pluginAssembly);
 
         }
 

--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -54,7 +54,7 @@ namespace SparkleXrm.Tasks
             AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve += (sender, args) => Assembly.ReflectionOnlyLoad(args.Name);
 
             // Search for any types that interhit from IPlugin                  
-            IEnumerable<Type> pluginTypes = Reflection.GetTypesInheritingFrom(peekAssembly, typeof(System.Activities.CodeActivity));
+            var pluginTypes = GetTypesInheritingFromCodeActivity(peekAssembly);
 
             if (pluginTypes.Count() > 0)
             {
@@ -181,7 +181,7 @@ namespace SparkleXrm.Tasks
             _trace.WriteLine("Checking assembly '{0}' for plugins", assemblyFilePath.Name);
 
             // Search for any types that interhit from IPlugin                  
-            IEnumerable<Type> pluginTypes = Reflection.GetTypesImplementingInterface(peekAssembly, typeof(Microsoft.Xrm.Sdk.IPlugin));
+            var pluginTypes = GetTypesImplementingIPlugin(peekAssembly);
 
             if (pluginTypes.Count() > 0)
             {
@@ -210,11 +210,9 @@ namespace SparkleXrm.Tasks
             _trace.WriteLine("Checking assembly '{0}' for plugins and workflows",
                              assemblyFilePath.Name);
 
-            // Search for any types that interhit from IPlugin                  
-            var pluginTypes = Reflection.GetTypesImplementingInterface(peekAssembly,
-                                                                       typeof(IPlugin));
-            var workflowTypes = Reflection.GetTypesInheritingFrom(peekAssembly,
-                                                                  typeof(CodeActivity));
+            var pluginTypes = GetTypesImplementingIPlugin(peekAssembly);
+            var workflowTypes = GetTypesInheritingFromCodeActivity(peekAssembly);
+
             var typesToRegister = pluginTypes.Union(workflowTypes);
             if (typesToRegister.Any())
             {
@@ -611,5 +609,20 @@ namespace SparkleXrm.Tasks
           }
           return true;
         }
+
+        private IEnumerable<Type> GetTypesInheritingFromCodeActivity(
+          Assembly assemby) {
+
+            return Reflection.GetTypesInheritingFrom(assemby,
+                                                     typeof(CodeActivity));
+        }
+
+        public IEnumerable<Type> GetTypesImplementingIPlugin(
+          Assembly assembly) {
+
+            return Reflection.GetTypesImplementingInterface(assembly,
+                                                            typeof(IPlugin));
+        }
+
     }
 }

--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -246,9 +246,14 @@ namespace SparkleXrm.Tasks
             }
             if(!excludePluginSteps)
             {
+                // It seems that to honour intent behind
+                // https://github.com/scottdurow/SparkleXrm/pull/302 also
+                // activities need to be omitted when using this flag:
+                // "A useful time saver when deploying large assemblies and no
+                //  updates to the plugin steps are required."
                 RegisterPluginSteps(pluginTypes, pluginAssembly);
+                RegisterActivities(workflowTypes, pluginAssembly);
             }
-            RegisterActivities(workflowTypes, pluginAssembly);
 
         }
 

--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -225,18 +225,22 @@ namespace SparkleXrm.Tasks
             var workflowTypes = Reflection.GetTypesInheritingFrom(peekAssembly,
                                                                   typeof(CodeActivity));
             var typesToRegister = pluginTypes.Union(workflowTypes);
-            if (typesToRegister.Count() > 0)
+            if (typesToRegister.Any())
             {
                 _trace.WriteLine("{0} plugin(s) and {1} workflow activities found!",
                                  pluginTypes.Count(),
                                  workflowTypes.Count());
 
-                var plugin = RegisterAssembly(assemblyFilePath, peekAssembly, typesToRegister);
+                var pluginAssembly = RegisterAssembly(assemblyFilePath,
+                                                      peekAssembly,
+                                                      typesToRegister);
 
-                if (plugin != null &&
-                    !excludePluginSteps)
+                if (pluginAssembly == null) {
+                    return;
+                }
+                if(!excludePluginSteps)
                 {
-                    RegisterPluginSteps(typesToRegister, plugin);
+                    RegisterPluginSteps(pluginTypes, pluginAssembly);
                 }
             }
 

--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -41,7 +41,20 @@ namespace SparkleXrm.Tasks
         /// </summary>
         public string SolutionUniqueName { get; set; }
 
-        public void RegisterWorkflowActivities(string file)
+        /// <summary>
+        /// Registers workflow activites declared on assembly
+        /// on specified <paramref name="file"/>.
+        /// </summary>
+        /// <param name="file">
+        /// Path to assembly file.
+        /// </param>
+        /// <param name="excludePluginSteps">
+        /// If true custom workflow activity registrations aren't touched
+        /// during operation.
+        /// </param>
+        /// <seealso cref="RegisterPluginAndWorkflow(string, bool)"/>
+        public void RegisterWorkflowActivities(string file,
+                                              bool excludePluginSteps = false)
         {
             FileInfo assemblyFilePath = null;
             Assembly peekAssembly = null;
@@ -59,8 +72,14 @@ namespace SparkleXrm.Tasks
             if (pluginTypes.Count() > 0)
             {
                 var plugin = RegisterAssembly(assemblyFilePath, peekAssembly, pluginTypes);
-                if (plugin != null)
+                if (plugin != null &&
+                    !excludePluginSteps)
                 {
+                    // It seems that to honour intent behind
+                    // https://github.com/scottdurow/SparkleXrm/pull/302 also
+                    // activities need to be omitted when using this flag:
+                    // "A useful time saver when deploying large assemblies and no
+                    //  updates to the plugin steps are required."
                     RegisterActivities(pluginTypes, plugin);
                 }
             }
@@ -168,6 +187,7 @@ namespace SparkleXrm.Tasks
         }
 
 
+        /// <seealso cref="RegisterPluginAndWorkflow(string, bool)"/>
         public void RegisterPlugin(string file, bool excludePluginSteps = false)
         {
             FileInfo assemblyFilePath = null;
@@ -205,12 +225,9 @@ namespace SparkleXrm.Tasks
         /// Path to assembly file.
         /// </param>
         /// <param name="excludePluginSteps">
-        /// If true plugin steps aren't registered. At that case this method
-        /// effectively works just like
-        /// <see cref="RegisterActivities(IEnumerable{Type}, PluginAssembly)"/>
-        /// would behave.
+        /// If true plugin steps and custom workflow activity registrations
+        /// aren't touched during the operation.
         /// </param>
-        /// <seealso cref="RegisterPluginAndWorkflow(string)"/>
         public void RegisterPluginAndWorkflow(string file,
                                               bool excludePluginSteps = false)
         {

--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -242,6 +242,7 @@ namespace SparkleXrm.Tasks
                 {
                     RegisterPluginSteps(pluginTypes, pluginAssembly);
                 }
+                RegisterActivities(workflowTypes, pluginAssembly);
             }
 
         }

--- a/spkl/SparkleXrm.Tasks/SparkleXrm.Tasks.csproj
+++ b/spkl/SparkleXrm.Tasks/SparkleXrm.Tasks.csproj
@@ -139,6 +139,7 @@
     <Compile Include="CustomAttributeDataEx.cs" />
     <Compile Include="Exceptions.cs" />
     <Compile Include="TargetTypeEnum.cs" />
+    <Compile Include="Tasks\DeployPluginsAndWorkflowTask.cs" />
     <Compile Include="Tasks\DeployPluginsTask.cs" />
     <Compile Include="Config\PluginDeployConfig.cs" />
     <Compile Include="Tasks\DeployWebResourcesTask.cs" />

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsAndWorkflowTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsAndWorkflowTask.cs
@@ -7,8 +7,21 @@ using System.Linq;
 using System.Reflection;
 
 namespace SparkleXrm.Tasks {
+
+    /// <summary>
+    /// Deployment task to deploy both plugin steps and custom workflow
+    /// activity registrations on a single update.
+    /// </summary>
+    /// <remarks>
+    /// https://github.com/scottdurow/SparkleXrm/issues/366
+    /// </remarks>
     public class DeployPluginsAndWorkflowTask : BaseTask
     {
+
+        /// <summary>
+        /// When true plugin step and custom workflow activity registration
+        /// information isn't updated when deploying assembly.
+        /// </summary>
         public bool ExcludePluginSteps { get; set; }
 
         public DeployPluginsAndWorkflowTask(IOrganizationService service, ITrace trace) : base(service, trace)

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsAndWorkflowTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsAndWorkflowTask.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Client;
+using SparkleXrm.Tasks.Config;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace SparkleXrm.Tasks {
+    public class DeployPluginsAndWorkflowTask : BaseTask
+    {
+        public bool ExcludePluginSteps { get; set; }
+
+        public DeployPluginsAndWorkflowTask(IOrganizationService service, ITrace trace) : base(service, trace)
+        {
+          
+        }
+        public DeployPluginsAndWorkflowTask(OrganizationServiceContext ctx, ITrace trace) : base(ctx, trace)
+        {
+
+        }
+
+        protected override void ExecuteInternal(string folder, OrganizationServiceContext ctx)
+        {
+            _trace.WriteLine("Searching for plugin config in '{0}'", folder);
+            var configs = ServiceLocator.ConfigFileFactory.FindConfig(folder);
+
+            foreach (var config in configs)
+            {
+                _trace.WriteLine("Using Config '{0}'", config.filePath);
+                DeployPluginsAndWorkflows(ctx, config);
+            }
+            _trace.WriteLine("Processed {0} config(s)", configs.Count);
+        }
+
+        private void DeployPluginsAndWorkflows(OrganizationServiceContext ctx, ConfigFile config)
+        {
+            var plugins = config.GetPluginsConfig(this.Profile);
+            
+            foreach (var plugin in plugins)
+            {
+                List<string> assemblies = config.GetAssemblies(plugin);
+
+                var pluginRegistration = new PluginRegistraton(_service, ctx, _trace);
+
+                if (!string.IsNullOrEmpty(plugin.solution))
+                {
+                    pluginRegistration.SolutionUniqueName = plugin.solution;
+                }
+
+                foreach (var assemblyFilePath in assemblies)
+                {
+                    try
+                    {
+                        pluginRegistration.RegisterPluginAndWorkflow(assemblyFilePath, ExcludePluginSteps);
+                    }
+
+                    catch (ReflectionTypeLoadException ex)
+                    {
+                        throw new Exception(ex.LoaderExceptions.First().Message);
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsAndWorkflowTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsAndWorkflowTask.cs
@@ -24,18 +24,46 @@ namespace SparkleXrm.Tasks {
         /// </summary>
         public bool ExcludePluginSteps { get; set; }
 
-        public DeployPluginsAndWorkflowTask(IOrganizationService service, ITrace trace) : base(service, trace)
+        /// <summary>
+        /// Creates a new instance. For more information see base class
+        /// constructor
+        /// <see cref="BaseTask(IOrganizationService, ITrace)"/>.
+        /// </summary>
+        /// <param name="service"></param>
+        /// <param name="trace"></param>
+        public DeployPluginsAndWorkflowTask(IOrganizationService service,
+                                            ITrace trace)
+            : base(service, trace)
         {
           
         }
-        public DeployPluginsAndWorkflowTask(OrganizationServiceContext ctx, ITrace trace) : base(ctx, trace)
+
+        /// <summary>
+        /// Creates a new instance. For more information see base class
+        /// constructor
+        /// <see cref="BaseTask(OrganizationServiceContext, ITrace)" />.
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="trace"></param>
+        public DeployPluginsAndWorkflowTask(OrganizationServiceContext ctx,
+                                            ITrace trace)
+            : base(ctx, trace)
         {
 
         }
 
-        protected override void ExecuteInternal(string folder, OrganizationServiceContext ctx)
+        /// <summary>
+        /// See overrided method
+        /// <see cref="BaseTask.ExecuteInternal(string, OrganizationServiceContext)"/>
+        /// for intent.
+        /// </summary>
+        /// <param name="folder"></param>
+        /// <param name="ctx"></param>
+        protected override void ExecuteInternal(string folder,
+                                                OrganizationServiceContext ctx)
         {
-            _trace.WriteLine("Searching for plugin and workflow config in '{0}'", folder);
+            _trace.WriteLine("Searching for plugin and workflow config in '{0}'",
+                             folder);
             var configs = ServiceLocator.ConfigFileFactory.FindConfig(folder);
 
             foreach (var config in configs)
@@ -46,7 +74,8 @@ namespace SparkleXrm.Tasks {
             _trace.WriteLine("Processed {0} config(s)", configs.Count);
         }
 
-        private void DeployPluginsAndWorkflows(OrganizationServiceContext ctx, ConfigFile config)
+        private void DeployPluginsAndWorkflows(OrganizationServiceContext ctx,
+                                               ConfigFile config)
         {
             var plugins = config.GetPluginsConfig(this.Profile);
             
@@ -65,12 +94,17 @@ namespace SparkleXrm.Tasks {
                 {
                     try
                     {
-                        pluginRegistration.RegisterPluginAndWorkflow(assemblyFilePath, ExcludePluginSteps);
+                        pluginRegistration.RegisterPluginAndWorkflow(assemblyFilePath,
+                                                                     ExcludePluginSteps);
                     }
 
                     catch (ReflectionTypeLoadException ex)
                     {
-                        throw new Exception(ex.LoaderExceptions.First().Message);
+                        // TODO One shouldn't throw System.Exception. See https://docs.microsoft.com/en-us/dotnet/standard/exceptions/. This is left unhandled to keep exception throwing similar between differend spkl task classes which also seem to throw System.Exception.
+                        throw new Exception(ex.LoaderExceptions
+                                              .First()
+                                              .Message,
+                                            ex);
                     }
                 }
             }

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsAndWorkflowTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsAndWorkflowTask.cs
@@ -22,7 +22,7 @@ namespace SparkleXrm.Tasks {
 
         protected override void ExecuteInternal(string folder, OrganizationServiceContext ctx)
         {
-            _trace.WriteLine("Searching for plugin config in '{0}'", folder);
+            _trace.WriteLine("Searching for plugin and workflow config in '{0}'", folder);
             var configs = ServiceLocator.ConfigFileFactory.FindConfig(folder);
 
             foreach (var config in configs)

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsTask.cs
@@ -3,17 +3,18 @@ using Microsoft.Xrm.Sdk.Client;
 using SparkleXrm.Tasks.Config;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SparkleXrm.Tasks
 {
     public class DeployPluginsTask : BaseTask
     {
+        
+        /// <summary>
+        /// When true plugin step and custom workflow activity registration
+        /// information isn't updated when deploying assembly.
+        /// </summary>
         public bool ExcludePluginSteps { get; set; }
 
         public DeployPluginsTask(IOrganizationService service, ITrace trace) : base(service, trace)

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployWorkflowActivitiesTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployWorkflowActivitiesTask.cs
@@ -3,16 +3,20 @@ using Microsoft.Xrm.Sdk.Client;
 using SparkleXrm.Tasks.Config;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SparkleXrm.Tasks
 {
     public class DeployWorkflowActivitiesTask : BaseTask
     {
+
+        /// <summary>
+        /// When true plugin step and custom workflow activity registration
+        /// information isn't updated when deploying assembly.
+        /// </summary>
+        public bool ExcludePluginSteps { get; set; }
+
         public DeployWorkflowActivitiesTask(IOrganizationService service, ITrace trace) : base(service, trace)
         {
         }

--- a/spkl/spkl/CommandLineArgs.cs
+++ b/spkl/spkl/CommandLineArgs.cs
@@ -1,9 +1,4 @@
 ﻿using CmdLine;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SparkleXrmTask
 {
@@ -16,6 +11,7 @@ namespace SparkleXrmTask
         [CommandLineParameter(Name = "task", ParameterIndex = 1, Required = true, Description = @"
 plugins = Deploy Plugins
 workflow = Deploy Workflows
+pluginandworkflows = Deploy both plugins and workflows
 webresources = Deploy webresources
 instrument = Download plugin/workflows and add code attributes to existing classes
 get-webresources = Download webresources and match to the local files to create a spkl.json file for deployment

--- a/spkl/spkl/CommandLineArgs.cs
+++ b/spkl/spkl/CommandLineArgs.cs
@@ -45,7 +45,7 @@ import = Packs a solution as per the 'pack' task, and then imports into Dynamics
         [CommandLineParameter(Name = "Ignore Windows login", Command = "i", Required = false, Description = "Optional flag to ignore logged in windows credentials during discovery and always ask for username/password.")]
         public bool IgnoreLocalPrincipal { get; set; }
 
-        [CommandLineParameter(Name = "Exclude Plugin Steps", Command = "e", Required = false, Description = "Exclude plugin steps when deploying plugins")]
+        [CommandLineParameter(Name = "Exclude Plugin Steps and workflow activities", Command = "e", Required = false, Description = "Do not update plugin step and custom workflow activity registration information when deploying assembly")]
         public bool ExcludePluginSteps { get; set; }
     }
 }

--- a/spkl/spkl/Program.cs
+++ b/spkl/spkl/Program.cs
@@ -307,7 +307,10 @@ namespace SparkleXrmTask
 
                 case "workflow":
                     trace.WriteLine("Deploying Custom Workflow Activities");
-                    task = new DeployWorkflowActivitiesTask(service, trace);
+                    task = new DeployWorkflowActivitiesTask(service, trace)
+                    {
+                      ExcludePluginSteps = arguments.ExcludePluginSteps
+                    };
                     break;
 
                 case "pluginandworkflows":

--- a/spkl/spkl/Program.cs
+++ b/spkl/spkl/Program.cs
@@ -18,19 +18,19 @@ using System.Threading.Tasks;
 namespace SparkleXrmTask
 {
     internal class Program
-    {  
+    {
         private static void Main(string[] args)
         {
             Console.ForegroundColor = ConsoleColor.DarkYellow;
             Console.WriteLine("spkl Task Runner v" + Assembly.GetEntryAssembly().GetName().Version + "\tTasks v" + Assembly.GetAssembly(typeof(SparkleXrm.Tasks.BaseTask)).GetName().Version);
-          
+
             Console.ForegroundColor = ConsoleColor.Gray;
             bool error = false;
             CommandLineArgs arguments = null;
             try
             {
                 arguments = CommandLine.Parse<CommandLineArgs>();
-                
+
                 Run(arguments);
             }
             catch (CommandLineException exception)
@@ -86,12 +86,12 @@ namespace SparkleXrmTask
                 Console.WriteLine(ex.Message);
                 Console.ForegroundColor = ConsoleColor.DarkGray;
                 Console.WriteLine(ex.StackTrace);
-                
+
                 // Display the details of the inner exception.
                 if (ex.InnerException != null)
                 {
                     Console.WriteLine(ex.InnerException.Message);
-                   
+
                     FaultException<Microsoft.Xrm.Sdk.OrganizationServiceFault> fe = ex.InnerException
                         as FaultException<Microsoft.Xrm.Sdk.OrganizationServiceFault>;
                     if (fe != null)
@@ -144,7 +144,7 @@ namespace SparkleXrmTask
                     // No Connection is supplied to ask for connection on command line 
                     ServerConnection serverConnect = new ServerConnection();
                     ServerConnection.Configuration config = serverConnect.GetServerConfiguration(arguments.IgnoreLocalPrincipal);
-                   
+
                     arguments.Connection = BuildConnectionString(config);
 
                     using (var serviceProxy = new OrganizationServiceProxy(config.OrganizationUri, config.HomeRealmUri, config.Credentials, config.DeviceCredentials))
@@ -208,7 +208,7 @@ namespace SparkleXrmTask
 
             // AuthType=AD;Url=http://contoso:8080/Test; Domain=CONTOSO; Username=jsmith; Password=passcode
 
-            // Office 365 
+            // Office 365
             // AuthType = Office365; Username = jsmith@contoso.onmicrosoft.com; Password = passcode; Url = https://contoso.crm.dynamics.com
 
             // IFD
@@ -288,7 +288,7 @@ namespace SparkleXrmTask
                 arguments.Path = arguments.Path.TrimEnd('\\');
                 arguments.Path = Path.Combine(Directory.GetCurrentDirectory(), arguments.Path);
             }
-         
+
             BaseTask task = null;
             string command = arguments.Task.ToLower();
             switch (command)
@@ -400,7 +400,7 @@ namespace SparkleXrmTask
                 task.Execute(arguments.Path);
             }
             else
-                throw new SparkleTaskException(SparkleTaskException.ExceptionTypes.NO_TASK_SUPPLIED, String.Format("Task '{0}' not recognised. Please consult help!", arguments.Task.ToLower()));            
+                throw new SparkleTaskException(SparkleTaskException.ExceptionTypes.NO_TASK_SUPPLIED, String.Format("Task '{0}' not recognised. Please consult help!", arguments.Task.ToLower()));
         }
     }
 }

--- a/spkl/spkl/Program.cs
+++ b/spkl/spkl/Program.cs
@@ -18,19 +18,19 @@ using System.Threading.Tasks;
 namespace SparkleXrmTask
 {
     internal class Program
-    {
+    {  
         private static void Main(string[] args)
         {
             Console.ForegroundColor = ConsoleColor.DarkYellow;
             Console.WriteLine("spkl Task Runner v" + Assembly.GetEntryAssembly().GetName().Version + "\tTasks v" + Assembly.GetAssembly(typeof(SparkleXrm.Tasks.BaseTask)).GetName().Version);
-
+          
             Console.ForegroundColor = ConsoleColor.Gray;
             bool error = false;
             CommandLineArgs arguments = null;
             try
             {
                 arguments = CommandLine.Parse<CommandLineArgs>();
-
+                
                 Run(arguments);
             }
             catch (CommandLineException exception)
@@ -86,12 +86,12 @@ namespace SparkleXrmTask
                 Console.WriteLine(ex.Message);
                 Console.ForegroundColor = ConsoleColor.DarkGray;
                 Console.WriteLine(ex.StackTrace);
-
+                
                 // Display the details of the inner exception.
                 if (ex.InnerException != null)
                 {
                     Console.WriteLine(ex.InnerException.Message);
-
+                   
                     FaultException<Microsoft.Xrm.Sdk.OrganizationServiceFault> fe = ex.InnerException
                         as FaultException<Microsoft.Xrm.Sdk.OrganizationServiceFault>;
                     if (fe != null)
@@ -141,10 +141,10 @@ namespace SparkleXrmTask
 
                 if (arguments.Connection == null)
                 {
-                    // No Connection is supplied to ask for connection on command line
+                    // No Connection is supplied to ask for connection on command line 
                     ServerConnection serverConnect = new ServerConnection();
                     ServerConnection.Configuration config = serverConnect.GetServerConfiguration(arguments.IgnoreLocalPrincipal);
-
+                   
                     arguments.Connection = BuildConnectionString(config);
 
                     using (var serviceProxy = new OrganizationServiceProxy(config.OrganizationUri, config.HomeRealmUri, config.Credentials, config.DeviceCredentials))
@@ -208,7 +208,7 @@ namespace SparkleXrmTask
 
             // AuthType=AD;Url=http://contoso:8080/Test; Domain=CONTOSO; Username=jsmith; Password=passcode
 
-            // Office 365
+            // Office 365 
             // AuthType = Office365; Username = jsmith@contoso.onmicrosoft.com; Password = passcode; Url = https://contoso.crm.dynamics.com
 
             // IFD
@@ -288,7 +288,7 @@ namespace SparkleXrmTask
                 arguments.Path = arguments.Path.TrimEnd('\\');
                 arguments.Path = Path.Combine(Directory.GetCurrentDirectory(), arguments.Path);
             }
-
+         
             BaseTask task = null;
             string command = arguments.Task.ToLower();
             switch (command)
@@ -308,6 +308,14 @@ namespace SparkleXrmTask
                 case "workflow":
                     trace.WriteLine("Deploying Custom Workflow Activities");
                     task = new DeployWorkflowActivitiesTask(service, trace);
+                    break;
+
+                case "pluginandworkflows":
+                    trace.WriteLine("Deploying Plugin and workflows");
+                    task = new DeployPluginsAndWorkflowTask(service, trace)
+                    {
+                      ExcludePluginSteps = arguments.ExcludePluginSteps
+                    };
                     break;
 
                 case "webresources":
@@ -389,7 +397,7 @@ namespace SparkleXrmTask
                 task.Execute(arguments.Path);
             }
             else
-                throw new SparkleTaskException(SparkleTaskException.ExceptionTypes.NO_TASK_SUPPLIED, String.Format("Task '{0}' not recognised. Please consult help!", arguments.Task.ToLower()));
+                throw new SparkleTaskException(SparkleTaskException.ExceptionTypes.NO_TASK_SUPPLIED, String.Format("Task '{0}' not recognised. Please consult help!", arguments.Task.ToLower()));            
         }
     }
 }

--- a/spkl/spkl/Program.cs
+++ b/spkl/spkl/Program.cs
@@ -141,7 +141,7 @@ namespace SparkleXrmTask
 
                 if (arguments.Connection == null)
                 {
-                    // No Connection is supplied to ask for connection on command line 
+                    // No Connection is supplied to ask for connection on command line
                     ServerConnection serverConnect = new ServerConnection();
                     ServerConnection.Configuration config = serverConnect.GetServerConfiguration(arguments.IgnoreLocalPrincipal);
 


### PR DESCRIPTION
This is PR to functionality looked after on issue #366. This PR adds new command `pluginandworkflows` to spkl.exe. This command simultaneously registers and updates plugin steps and custom workflow activities present on same assembly into CDS. Previously you haven't been able to do this.

If command line argument `/e` introduced is PR #302 is present then only assembly is updated and registration information of steps and activities is left intact on CDS. I updated also `workflow` task to use `/e` flag because otherwise it would've behaved differently from other two registration tasks. I made this change because I felt it was honouring the intent of #302 which was to speed up updates of large assemblies when there were changes only to assembly and not in registrations.