### PR TITLE
Fix for issue #376

### DIFF
--- a/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsTask.cs
@@ -16,6 +16,8 @@ namespace SparkleXrm.Tasks
     {
         public bool ExcludePluginSteps { get; set; }
 
+        public string PublisherPrefix { get; set; }
+
         public DeployPluginsTask(IOrganizationService service, ITrace trace) : base(service, trace)
         {
           
@@ -57,7 +59,7 @@ namespace SparkleXrm.Tasks
                 {
                     try
                     {
-                        pluginRegistration.RegisterPlugin(assemblyFilePath, ExcludePluginSteps);
+                        pluginRegistration.RegisterPlugin(assemblyFilePath, ExcludePluginSteps, PublisherPrefix);
                     }
 
                     catch (ReflectionTypeLoadException ex)

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployWorkflowActivitiesTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployWorkflowActivitiesTask.cs
@@ -13,6 +13,8 @@ namespace SparkleXrm.Tasks
 {
     public class DeployWorkflowActivitiesTask : BaseTask
     {
+        public string PublisherPrefix { get; set; }
+
         public DeployWorkflowActivitiesTask(IOrganizationService service, ITrace trace) : base(service, trace)
         {
         }
@@ -49,7 +51,7 @@ namespace SparkleXrm.Tasks
                 {
                     try
                     {
-                        pluginRegistration.RegisterWorkflowActivities(assemblyFilePath);
+                        pluginRegistration.RegisterWorkflowActivities(assemblyFilePath, PublisherPrefix);
                     }
                     catch (ReflectionTypeLoadException ex)
                     {

--- a/spkl/spkl/Program.cs
+++ b/spkl/spkl/Program.cs
@@ -299,12 +299,18 @@ namespace SparkleXrmTask
                 case "plugins":
                     trace.WriteLine("Deploying Plugins");
                     task = new DeployPluginsTask(service, trace)
-                    { ExcludePluginSteps = arguments.ExcludePluginSteps };
+                    {
+                        ExcludePluginSteps = arguments.ExcludePluginSteps,
+                        PublisherPrefix = arguments.Prefix
+                    };
                     break;
 
                 case "workflow":
                     trace.WriteLine("Deploying Custom Workflow Activities");
-                    task = new DeployWorkflowActivitiesTask(service, trace);
+                    task = new DeployWorkflowActivitiesTask(service, trace)
+                    {
+                        PublisherPrefix = arguments.Prefix
+                    };
                     break;
 
                 case "webresources":


### PR DESCRIPTION
Fixes issue #376 by introducing the IgnoreAssembly method which ignores all assemblies from a hardcoded set of publishers. Also a possibility of deploying assemblies from only a specified publisher is added, the 'solution prefix' command line argument serves as publisher prefix source.