### PR TITLE
Fix for issue #376

### DIFF
--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -30,10 +30,10 @@ namespace SparkleXrm.Tasks
         /// </summary>
         public string SolutionUniqueName { get; set; }
 
-        public void RegisterWorkflowActivities(string path)
+        public void RegisterWorkflowActivities(string path, string publisherPrefix = "")
         {
             var assemblyFilePath = new FileInfo(path);
-            if (Reflection.IgnoredAssemblies.Contains(assemblyFilePath.Name))
+            if (Reflection.IgnoreAssembly(assemblyFilePath, publisherPrefix))
                 return;
             // Load each assembly
             Assembly assembly = Reflection.LoadAssembly(assemblyFilePath.FullName);
@@ -148,11 +148,11 @@ namespace SparkleXrm.Tasks
             _service.Execute(addToSolution);
         }
 
-        public void RegisterPlugin(string file, bool excludePluginSteps = false)
+        public void RegisterPlugin(string file, bool excludePluginSteps = false, string publisherPrefix = "")
         {
             var assemblyFilePath = new FileInfo(file);
 
-            if (assemblyFilePath.Name.StartsWith("System.") || Reflection.IgnoredAssemblies.Contains(assemblyFilePath.Name))
+            if (Reflection.IgnoreAssembly(assemblyFilePath, publisherPrefix))
                 return;
 
             // Load each assembly

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployPluginsTask.cs
@@ -16,6 +16,8 @@ namespace SparkleXrm.Tasks
     {
         public bool ExcludePluginSteps { get; set; }
 
+        public string PublisherPrefix { get; set; }
+
         public DeployPluginsTask(IOrganizationService service, ITrace trace) : base(service, trace)
         {
           
@@ -57,7 +59,7 @@ namespace SparkleXrm.Tasks
                 {
                     try
                     {
-                        pluginRegistration.RegisterPlugin(assemblyFilePath, ExcludePluginSteps);
+                        pluginRegistration.RegisterPlugin(assemblyFilePath, ExcludePluginSteps, PublisherPrefix);
                     }
 
                     catch (ReflectionTypeLoadException ex)

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployWorkflowActivitiesTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployWorkflowActivitiesTask.cs
@@ -13,6 +13,8 @@ namespace SparkleXrm.Tasks
 {
     public class DeployWorkflowActivitiesTask : BaseTask
     {
+        public string PublisherPrefix { get; set; }
+
         public DeployWorkflowActivitiesTask(IOrganizationService service, ITrace trace) : base(service, trace)
         {
         }
@@ -49,7 +51,7 @@ namespace SparkleXrm.Tasks
                 {
                     try
                     {
-                        pluginRegistration.RegisterWorkflowActivities(assemblyFilePath);
+                        pluginRegistration.RegisterWorkflowActivities(assemblyFilePath, PublisherPrefix);
                     }
                     catch (ReflectionTypeLoadException ex)
                     {

--- a/spkl/spkl/Program.cs
+++ b/spkl/spkl/Program.cs
@@ -325,12 +325,18 @@ namespace SparkleXrmTask
                 case "plugins":
                     trace.WriteLine("Deploying Plugins");
                     task = new DeployPluginsTask(service, trace)
-                    { ExcludePluginSteps = arguments.ExcludePluginSteps };
+                    {
+                        ExcludePluginSteps = arguments.ExcludePluginSteps,
+                        PublisherPrefix = arguments.Prefix
+                    };
                     break;
 
                 case "workflow":
                     trace.WriteLine("Deploying Custom Workflow Activities");
-                    task = new DeployWorkflowActivitiesTask(service, trace);
+                    task = new DeployWorkflowActivitiesTask(service, trace)
+                    {
+                        PublisherPrefix = arguments.Prefix
+                    };
                     break;
 
                 case "webresources":


### PR DESCRIPTION
This PR introduces the IgnoreAssembly method that checks if an assembly should be ignored on Plugins and Workflow assemblies import tasks. If the 'solution prefix' command line argument is specified it is used for assembly name matching and matched assemblies are deployed. If no solution prefix is provided or an assembly does not match the prefix it is matched against a list of ignored publishers via a regex. So it's a 'white list' - 'black list' scheme for assembly checking before deployment. If solution prefix is provided we can do 'white list' check, if no prefix is provided or an assembly didn't pass this check, a 'black list' check is conducted using the ignored publishers list.
A few points to highlight:
- the ignored publishers list is a more general scheme compared to existing ignored assemblies list and is less likely to require extension in the future,
- all assemblies in the current ignored assemblies list will be matched when doing ignored publishers list check so this solution is backwards compatible,
- the IgnoreAssembly method is backwards compatible since it does not require solution prefix to work and without it it will work like existing ignored assemblies list.