### PR TITLE
Updated To use EarlyBoundGenerator.Api.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ UpgradeLog*.XML
 *.ide-shm
 *.ide-wal
 /.vs
+/spkl/.vs/spkl

--- a/spkl/CrmSvcUtilFilteringService/CodeGenerationService.cs
+++ b/spkl/CrmSvcUtilFilteringService/CodeGenerationService.cs
@@ -15,7 +15,7 @@ namespace spkl.CrmSvcUtilExtensions
     using Microsoft.Xrm.Sdk.Client;
     using System.Reflection;
 
-    public class CodeGenerationService : ICodeGenerationService
+    internal class CodeGenerationService : ICodeGenerationService
     {
         private ICodeGenerationService _defaultService;
 

--- a/spkl/CrmSvcUtilFilteringService/CrmSvcUtil.FilteringService.csproj
+++ b/spkl/CrmSvcUtilFilteringService/CrmSvcUtil.FilteringService.csproj
@@ -51,6 +51,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.CrmSdk.CoreTools.9.0.0.7\content\bin\coretools\CrmSvcUtil.exe</HintPath>
     </Reference>
+    <Reference Include="DLaB.EarlyBoundGenerator.Api, Version=1.2020.4.21, Culture=neutral, PublicKeyToken=915c5118a4c943b9, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.EarlyBoundGenerator.Api.1.2020.4.21\lib\net462\DLaB.EarlyBoundGenerator.Api.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.0.7\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
@@ -64,6 +67,7 @@
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.22.302111727\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.0.7\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
@@ -109,6 +113,14 @@
     <None Include="app.config" />
     <None Include="bin\coretools\CrmSvcUtil.exe.config" />
     <None Include="bin\coretools\LicenseTerms.docx" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1031.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1036.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1040.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1044.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1045.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1049.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1058.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\CrmSvcUtil.exe.config" />
     <None Include="spkl.crmsvcutil.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
@@ -130,6 +142,21 @@
     <Content Include="bin\coretools\Microsoft.Xrm.Tooling.Ui.Styles.dll" />
     <Content Include="bin\coretools\Other Redistributable.txt" />
     <Content Include="bin\coretools\SolutionPackager.exe" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\CrmSvcUtil.exe" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\DLaB.CrmSvcUtilExtensions.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Crm.Sdk.Proxy.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Rest.ClientRuntime.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Client.CodeGeneration.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Client.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Sdk.Deployment.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Sdk.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.Connector.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.CrmConnectControl.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.Ui.Styles.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.WebResourceUtility.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Newtonsoft.Json.dll" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="bin\Debug\" />

--- a/spkl/CrmSvcUtilFilteringService/FilteringService.cs
+++ b/spkl/CrmSvcUtilFilteringService/FilteringService.cs
@@ -10,7 +10,7 @@
     /// <summary>
     /// Allows filtering of the metadata to only generate the entities that we want
     /// </summary>
-    public sealed class FilteringService : ICodeWriterFilterService
+    internal sealed class FilteringService : ICodeWriterFilterService
     {
         private List<string> _entities = null;
         private string _entityLogicalName = null;

--- a/spkl/CrmSvcUtilFilteringService/MessageFilteringService.cs
+++ b/spkl/CrmSvcUtilFilteringService/MessageFilteringService.cs
@@ -9,7 +9,7 @@
     /// <summary>
     /// Allows filtering of the message so that we only generate the actions we want
     /// </summary>
-    public class MessageFilteringService : ICodeWriterMessageFilterService
+    internal class MessageFilteringService : ICodeWriterMessageFilterService
     {
         private List<string> _messageFilter;
 

--- a/spkl/CrmSvcUtilFilteringService/MetadataProviderQueryService.cs
+++ b/spkl/CrmSvcUtilFilteringService/MetadataProviderQueryService.cs
@@ -10,7 +10,7 @@
     using System.Globalization;
     using System.Xml.Linq;
 
-    public sealed class MetadataProviderQueryService : IMetadataProviderQueryService
+    internal sealed class MetadataProviderQueryService : IMetadataProviderQueryService
     {
         private static List<string> _excludedNamespaces;
         private IDictionary<string, string> _parameters;

--- a/spkl/CrmSvcUtilFilteringService/app.config
+++ b/spkl/CrmSvcUtilFilteringService/app.config
@@ -14,6 +14,10 @@
         <assemblyIdentity name="Microsoft.Xrm.Tooling.Connector" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.19.8.16603" newVersion="3.19.8.16603" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/spkl/CrmSvcUtilFilteringService/packages.config
+++ b/spkl/CrmSvcUtilFilteringService/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="DLaB.Xrm.EarlyBoundGenerator.Api" version="1.2020.4.21" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.7" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.CoreTools" version="9.0.0.7" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.0.7" targetFramework="net462" />

--- a/spkl/SparkleXrm.Tasks.Tests/SparkleXrm.Tasks.Tests.csproj
+++ b/spkl/SparkleXrm.Tasks.Tests/SparkleXrm.Tasks.Tests.csproj
@@ -44,6 +44,9 @@
     <AssemblyOriginatorKeyFile>Plugins.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DLaB.EarlyBoundGenerator.Api, Version=1.2020.5.5, Culture=neutral, PublicKeyToken=915c5118a4c943b9, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.EarlyBoundGenerator.Api.1.2020.5.5\lib\net462\DLaB.EarlyBoundGenerator.Api.dll</HintPath>
+    </Reference>
     <Reference Include="FakeItEasy, Version=4.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
       <HintPath>..\packages\FakeItEasy.4.1.1\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
@@ -56,6 +59,7 @@
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.22.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.22.302111727\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>
@@ -138,6 +142,16 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="bin\Debug\SparkleXrm.Tasks.dll.config" />
+    <None Include="bin\Debug\SparkleXrm.Tasks.Tests.dll.config" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1031.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1036.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1040.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1044.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1045.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1049.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1058.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\CrmSvcUtil.exe.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
@@ -158,6 +172,67 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\CustomBaseClassPlugin.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="bin\Debug\DLaB.EarlyBoundGenerator.Api.dll" />
+    <Content Include="bin\Debug\FakeItEasy.dll" />
+    <Content Include="bin\Debug\FakeItEasy.pdb" />
+    <Content Include="bin\Debug\FakeItEasy.xml" />
+    <Content Include="bin\Debug\Log10.txt" />
+    <Content Include="bin\Debug\Log12.txt" />
+    <Content Include="bin\Debug\Log15.txt" />
+    <Content Include="bin\Debug\Log17.txt" />
+    <Content Include="bin\Debug\Log18.txt" />
+    <Content Include="bin\Debug\Log19.txt" />
+    <Content Include="bin\Debug\Log20.txt" />
+    <Content Include="bin\Debug\Log21.txt" />
+    <Content Include="bin\Debug\Log22.txt" />
+    <Content Include="bin\Debug\Log24.txt" />
+    <Content Include="bin\Debug\Log27.txt" />
+    <Content Include="bin\Debug\Log8.txt" />
+    <Content Include="bin\Debug\Microsoft.Crm.Sdk.Proxy.dll" />
+    <Content Include="bin\Debug\Microsoft.Crm.Sdk.Proxy.xml" />
+    <Content Include="bin\Debug\Microsoft.Extensions.FileSystemGlobbing.dll" />
+    <Content Include="bin\Debug\Microsoft.Extensions.FileSystemGlobbing.xml" />
+    <Content Include="bin\Debug\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
+    <Content Include="bin\Debug\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" />
+    <Content Include="bin\Debug\Microsoft.IdentityModel.Clients.ActiveDirectory.xml" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Deployment.dll" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Deployment.xml" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.dll" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Workflow.dll" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Workflow.xml" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.xml" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Tooling.Connector.dll" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Tooling.Connector.xml" />
+    <Content Include="bin\Debug\netstandard.dll" />
+    <Content Include="bin\Debug\Newtonsoft.Json.dll" />
+    <Content Include="bin\Debug\SparkleXrm.Tasks.dll" />
+    <Content Include="bin\Debug\SparkleXrm.Tasks.pdb" />
+    <Content Include="bin\Debug\SparkleXrm.Tasks.Tests.dll" />
+    <Content Include="bin\Debug\SparkleXrm.Tasks.Tests.pdb" />
+    <Content Include="bin\Debug\System.Collections.Immutable.dll" />
+    <Content Include="bin\Debug\System.Collections.Immutable.xml" />
+    <Content Include="bin\Debug\System.Runtime.dll" />
+    <Content Include="bin\Debug\System.Runtime.Extensions.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\CrmSvcUtil.exe" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\DLaB.CrmSvcUtilExtensions.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Crm.Sdk.Proxy.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Rest.ClientRuntime.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Client.CodeGeneration.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Client.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Sdk.Deployment.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Sdk.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.Connector.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.CrmConnectControl.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.Ui.Styles.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.WebResourceUtility.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Newtonsoft.Json.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="bin\Release\" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/spkl/SparkleXrm.Tasks.Tests/packages.config
+++ b/spkl/SparkleXrm.Tasks.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="DLaB.Xrm.EarlyBoundGenerator.Api" version="1.2020.5.5" targetFramework="net462" />
   <package id="FakeItEasy" version="4.1.1" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.7" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.0.7" targetFramework="net462" />

--- a/spkl/SparkleXrm.Tasks/Config/ConfigFile.cs
+++ b/spkl/SparkleXrm.Tasks/Config/ConfigFile.cs
@@ -60,8 +60,7 @@ namespace SparkleXrm.Tasks.Config
                     filename ="Entities.cs",
                     entities = "account,contact",
                     classNamespace = "Xrm",
-                    generateOptionsetEnums = true,
-                    generateStateEnums = true
+                    generateOptionsetEnums = true
                 } };
                     
             EarlyBoundTypeConfig[] config = null;

--- a/spkl/SparkleXrm.Tasks/Config/EarlyBoundTypeConfig.cs
+++ b/spkl/SparkleXrm.Tasks/Config/EarlyBoundTypeConfig.cs
@@ -6,14 +6,15 @@ using System.Threading.Tasks;
 
 namespace SparkleXrm.Tasks.Config
 {
-    public class EarlyBoundTypeConfig
+    public class EarlyBoundTypeConfig : DLaB.EarlyBoundGenerator.Settings.POCO.ExtensionConfig
     {
         public string profile;
         public string entities;
         public string actions;
         public bool generateOptionsetEnums;
-        public bool generateGlobalOptionsets;
-        public bool generateStateEnums;
+        public bool? generateActions;
+        public string actionFilename;
+        public string optionSetFilename;
         public string filename;
         public string classNamespace;
         public string serviceContextName;

--- a/spkl/SparkleXrm.Tasks/SparkleXrm.Tasks.csproj
+++ b/spkl/SparkleXrm.Tasks/SparkleXrm.Tasks.csproj
@@ -37,6 +37,9 @@
     <AssemblyOriginatorKeyFile>SparkleXrm.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="DLaB.EarlyBoundGenerator.Api, Version=1.2020.5.5, Culture=neutral, PublicKeyToken=915c5118a4c943b9, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.EarlyBoundGenerator.Api.1.2020.5.5\lib\net462\DLaB.EarlyBoundGenerator.Api.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.0.5\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
       <Private>True</Private>
@@ -55,6 +58,7 @@
     <Reference Include="Microsoft.QualityTools.Testing.Fakes, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.0.5\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
       <Private>True</Private>
@@ -78,6 +82,7 @@
     <Reference Include="System" />
     <Reference Include="System.Activities" />
     <Reference Include="System.Activities.Presentation" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
@@ -144,6 +149,14 @@
     </None>
     <None Include="bin\coretools\CrmSvcUtil.exe.config" />
     <None Include="bin\coretools\LicenseTerms.docx" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1031.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1036.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1040.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1044.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1045.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1049.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1058.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\CrmSvcUtil.exe.config" />
     <None Include="EarlyBound.bat" />
     <None Include="spkl.json" />
     <None Include="packages.config">
@@ -168,6 +181,21 @@
     <Content Include="bin\coretools\Microsoft.Xrm.Tooling.Ui.Styles.dll" />
     <Content Include="bin\coretools\Other Redistributable.txt" />
     <Content Include="bin\coretools\SolutionPackager.exe" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\CrmSvcUtil.exe" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\DLaB.CrmSvcUtilExtensions.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Crm.Sdk.Proxy.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Rest.ClientRuntime.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Client.CodeGeneration.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Client.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Sdk.Deployment.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Sdk.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.Connector.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.CrmConnectControl.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.Ui.Styles.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.WebResourceUtility.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Newtonsoft.Json.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/spkl/SparkleXrm.Tasks/Tasks/EarlyBoundClassGeneratorTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/EarlyBoundClassGeneratorTask.cs
@@ -1,21 +1,17 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using SparkleXrm.Tasks.Config;
 using System.IO;
 using System.Diagnostics;
-using SparkleXrm.Tasks.CrmSvcUtil;
+using DLaB.EarlyBoundGenerator;
+using DLaB.Log;
 
 namespace SparkleXrm.Tasks
 {
     public class EarlyBoundClassGeneratorTask : BaseTask
     {
         public string ConectionString {get;set;}
-        private string _folder;
         public EarlyBoundClassGeneratorTask(IOrganizationService service, ITrace trace) : base(service, trace)
         {
         }
@@ -42,133 +38,165 @@ namespace SparkleXrm.Tasks
 
         public void CreateEarlyBoundTypes(OrganizationServiceContext ctx, ConfigFile config)
         {
-            _folder = config.filePath;
+            Logger.Instance.OnLog += DLaBOnLog;
+            var crmSvcUtilPath = GetCrmSvcUtilPath();
 
-            // locate the CrmSvcUtil package folder
-            var targetfolder = ServiceLocator.DirectoryService.GetApplicationDirectory();
-            
-            // If we are running in VS, then move up past bin/Debug
-            if (targetfolder.Contains(@"bin\Debug") || targetfolder.Contains(@"bin\Release"))
+            var earlyBoundTypeConfigs = config.GetEarlyBoundConfig(this.Profile);
+            foreach (var earlyboundConfig in earlyBoundTypeConfigs)
             {
-                targetfolder += @"\..";
+                var ebgConfig = DLaB.EarlyBoundGenerator.Settings.EarlyBoundGeneratorConfig.GetDefault();
+                ebgConfig.ExtensionConfig.SetPopulatedValues(earlyboundConfig);
+                ebgConfig.ExtensionConfig.EntitiesWhitelist = ConvertCommasToPipes(earlyboundConfig.entities);
+                ebgConfig.ExtensionConfig.ActionsWhitelist = ConvertCommasToPipes(earlyboundConfig.actions);
+
+                // Not sure if this should map or not.  
+                ebgConfig.ExtensionConfig.GenerateEnumProperties = earlyboundConfig.generateOptionsetEnums;
+
+                ebgConfig.EntityOutPath = GetFile(config.filePath, earlyboundConfig.filename, "entities.cs", earlyboundConfig.oneTypePerFile);
+                ebgConfig.ActionOutPath = GetFile(config.filePath, earlyboundConfig.actionFilename, "actions.cs", earlyboundConfig.oneTypePerFile);
+                ebgConfig.OptionSetOutPath = GetFile(config.filePath, earlyboundConfig.optionSetFilename, "optionsets.cs", earlyboundConfig.oneTypePerFile);
+                ebgConfig.SupportsActions = earlyboundConfig.generateActions != false && !string.IsNullOrWhiteSpace(earlyboundConfig.actions);
+                ebgConfig.Namespace = earlyboundConfig.classNamespace ?? "Xrm";
+                ebgConfig.ConnectionString = ConectionString;
+                ebgConfig.CrmSvcUtilRelativePath = crmSvcUtilPath;
+                ebgConfig.RootPath = Path.GetDirectoryName(crmSvcUtilPath);
+                ebgConfig.ServiceContextName = string.IsNullOrWhiteSpace(earlyboundConfig.serviceContextName) 
+                    ? ebgConfig.ServiceContextName
+                    : earlyboundConfig.serviceContextName;
+                if (earlyboundConfig.oneTypePerFile)
+                {
+                    ebgConfig.ExtensionConfig.CreateOneFilePerAction = true;
+                    ebgConfig.ExtensionConfig.CreateOneFilePerEntity = true;
+                    ebgConfig.ExtensionConfig.CreateOneFilePerOptionSet = true;
+                }
+
+
+                if (string.IsNullOrEmpty(ebgConfig.ConnectionString))
+                {
+                    throw new Exception("ConnectionString must be supplied for CrmSvcUtil");
+                }
+
+                var logic = new Logic(ebgConfig);
+                if (!earlyboundConfig.generateOptionsetEnums)
+                {
+                    if (ebgConfig.SupportsActions)
+                    {
+                        logic.CreateActions();
+                    }
+                    logic.CreateEntities();
+                }
+                else
+                {
+                    new Logic(ebgConfig).ExecuteAll();
+                }
+            }
+        }
+
+        private void DLaBOnLog(LogMessageInfo info)
+        {
+            _trace.WriteLine(info.ModalMessage);
+            if (info.Detail != null && info.Detail != info.ModalMessage)
+            {
+                _trace.WriteLine(info.Detail);
+            }
+        }
+
+        private string GetFile(string path, string configured, string fileTypeName, bool createOneFilePerType)
+        {
+            path = Path.Combine(path, string.IsNullOrWhiteSpace(configured) 
+                ? fileTypeName 
+                : configured);
+            if (createOneFilePerType && Path.GetExtension(path).ToLower() == ".cs")
+            {
+                path = Path.GetDirectoryName(path) + "\\" + Path.GetFileNameWithoutExtension(path) + "\\";
+            }
+            return path;
+        }
+
+
+        private string ConvertCommasToPipes(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+            return value.Replace(',', '|');
+        }
+
+        //private void RunProcess(string crmSvcUtilPath, string parameters, string crmSvcUtilFolder)
+        //{
+        //    var procStart = new ProcessStartInfo(crmSvcUtilPath, parameters)
+        //    {
+        //        WorkingDirectory = crmSvcUtilFolder,
+        //        RedirectStandardOutput = true,
+        //        RedirectStandardError = true,
+        //        CreateNoWindow = true,
+        //        UseShellExecute = false,
+        //        WindowStyle = ProcessWindowStyle.Hidden
+        //    };
+        //
+        //    _trace.WriteLine("Running {0} {1}", crmSvcUtilPath, parameters);
+        //    var exitCode = 0;
+        //    Process proc = null;
+        //    try
+        //    {
+        //        proc = Process.Start(procStart);
+        //        proc.OutputDataReceived += Proc_OutputDataReceived;
+        //        proc.ErrorDataReceived += Proc_OutputDataReceived;
+        //        proc.BeginOutputReadLine();
+        //        proc.BeginErrorReadLine();
+        //        proc.WaitForExit(20 * 60 * 60 * 1000);
+        //        proc.CancelOutputRead();
+        //        proc.CancelErrorRead();
+        //    }
+        //    finally
+        //    {
+        //        exitCode = proc.ExitCode;
+        //
+        //        proc.Close();
+        //    }
+        //
+        //    if (exitCode != 0)
+        //    {
+        //        throw new SparkleTaskException(SparkleTaskException.ExceptionTypes.CRMSVCUTIL_ERROR, $"CrmSvcUtil exited with error {exitCode}");
+        //    }
+        //}
+
+        private string GetCrmSvcUtilPath()
+        {
+            // locate the CrmSvcUtil package folder
+            var targetFolder = ServiceLocator.DirectoryService.GetApplicationDirectory();
+
+            // If we are running in VS, then move up past bin/Debug
+            if (targetFolder.Contains(@"bin\Debug") || targetFolder.Contains(@"bin\Release"))
+            {
+                targetFolder += @"\..";
             }
 
             // move from spkl.v.v.v.\tools - back to packages folder
-            var crmsvcutilPath = ServiceLocator.DirectoryService.SimpleSearch(targetfolder + @"\..\..", "crmsvcutil.exe");
-            _trace.WriteLine("Target {0}", targetfolder);
-            var crmsvcutilFolder = new FileInfo(crmsvcutilPath).DirectoryName;
-            if (string.IsNullOrEmpty(crmsvcutilPath))
+            var path = Path.GetFullPath(targetFolder + @"\..\..");
+            _trace.WriteLine("Target {0}", path);
+            var dLaBCrmSvcUtilExtPath = ServiceLocator.DirectoryService.SimpleSearch(path, "DLaB.CrmSvcUtilExtensions.dll");
+            if (string.IsNullOrEmpty(dLaBCrmSvcUtilExtPath))
             {
                 throw new SparkleTaskException(SparkleTaskException.ExceptionTypes.UTILSNOTFOUND,
-                    $"Cannot locate CrmSvcUtil at '{crmsvcutilPath}' - run Install-Package Microsoft.CrmSdk.CoreTools");
+                    $"Cannot locate DLaB.CrmSvcUtilExtensions.dll anywhere within '{path}' - run Install-Package DLaB.EarlyBoundGenerator.Api");
             }
 
-            // Copy the filtering assembly
-            var filteringAssemblyPathString = ServiceLocator.DirectoryService.SimpleSearch(targetfolder + @"\..\..", "spkl.CrmSvcUtilExtensions.dll");
-         
-            if (string.IsNullOrEmpty(filteringAssemblyPathString))
+            var crmSvcUtilFolder = new FileInfo(dLaBCrmSvcUtilExtPath).DirectoryName;
+            var crmSvcUtilPath = ServiceLocator.DirectoryService.SimpleSearch(crmSvcUtilFolder, "CrmSvcUtil.exe");
+            if (string.IsNullOrEmpty(crmSvcUtilPath))
             {
                 throw new SparkleTaskException(SparkleTaskException.ExceptionTypes.UTILSNOTFOUND,
-                    $"Cannot locate spkl.CrmSvcUtilExtensions.dll at '{crmsvcutilPath}' ");
-            }
-            var filteringAssemblyPath = new FileInfo(filteringAssemblyPathString);
-            var targetFilteringPath = Path.Combine(crmsvcutilFolder, "spkl.CrmSvcUtilExtensions.dll");
-
-            if (filteringAssemblyPath.FullName != targetFilteringPath)
-            {
-                File.Copy(filteringAssemblyPath.FullName, targetFilteringPath, true);
+                    $"Cannot locate CrmSvcUtil.exe at '{crmSvcUtilFolder}' - run Install-Package DLaB.EarlyBoundGenerator.Api");
             }
 
-            var earlyBoundTypeConfigs = config.GetEarlyBoundConfig(this.Profile);
-            foreach (var earlyboundconfig in earlyBoundTypeConfigs)
-            {
-                // Create config and copy to the CrmSvcUtil folder
-                var configXml = $@"<?xml version=""1.0"" encoding=""utf-8"" ?>
-                        <configuration>
-                            <entities>{earlyboundconfig.entities}</entities>
-                            <messages>{earlyboundconfig.actions}</messages>
-                            <picklistEnums>{
-                        earlyboundconfig.generateOptionsetEnums.ToString().ToLower()
-                    }</picklistEnums>
-                            <stateEnums>{earlyboundconfig.generateStateEnums.ToString().ToLower()}</stateEnums>
-                            <globalEnums>{earlyboundconfig.generateGlobalOptionsets.ToString().ToLower()}</globalEnums>
-                        </configuration>";
-
-                // Copy the filtering assembly to the CrmSvcUtil folder
-                File.WriteAllText(Path.Combine(crmsvcutilFolder, "spkl.crmsvcutil.config"), configXml);
-
-                if (string.IsNullOrEmpty(this.ConectionString))
-                    throw new Exception("ConnectionString must be supplied for CrmSvcUtil");
-
-                // Run CrmSvcUtil 
-                var parameters =
-                    $@"/connstr:""{this.ConectionString}"" /out:""{
-                        Path.Combine(this._folder, earlyboundconfig.filename)
-                    }"" /namespace:""{earlyboundconfig.classNamespace}"" /serviceContextName:""{
-                        earlyboundconfig.serviceContextName
-                    }"" /GenerateActions:""{
-                        !String.IsNullOrEmpty(earlyboundconfig.actions)
-                    }"" /codewriterfilter:""spkl.CrmSvcUtilExtensions.FilteringService,spkl.CrmSvcUtilExtensions"" /codewritermessagefilter:""spkl.CrmSvcUtilExtensions.MessageFilteringService,spkl.CrmSvcUtilExtensions"" /codegenerationservice:""spkl.CrmSvcUtilExtensions.CodeGenerationService, spkl.CrmSvcUtilExtensions"" /metadataproviderqueryservice:""spkl.CrmSvcUtilExtensions.MetadataProviderQueryService,spkl.CrmSvcUtilExtensions""";
-
-                var procStart = new ProcessStartInfo(crmsvcutilPath, parameters)
-                {
-                    WorkingDirectory = crmsvcutilFolder,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    WindowStyle = ProcessWindowStyle.Hidden
-                };
-
-                _trace.WriteLine("Running {0} {1}", crmsvcutilPath, parameters);
-                var exitCode = 0;
-                Process proc = null;
-                try
-                {
-                    proc = Process.Start(procStart);
-                    proc.OutputDataReceived += Proc_OutputDataReceived;
-                    proc.ErrorDataReceived += Proc_OutputDataReceived;
-                    proc.BeginOutputReadLine();
-                    proc.BeginErrorReadLine();
-                    proc.WaitForExit(20 * 60 * 60 * 1000);
-                    proc.CancelOutputRead();
-                    proc.CancelErrorRead();
-                }
-                finally
-                {
-                    exitCode = proc.ExitCode;
-                   
-                    proc.Close();
-                }
-
-                if (exitCode!=0)
-                {
-                    throw new SparkleTaskException(SparkleTaskException.ExceptionTypes.CRMSVCUTIL_ERROR, $"CrmSvcUtil exited with error {exitCode}");
-                }
-
-                // Now that crmsvcutil has created the earlybound class file let's split it into separate files if this what the user wants
-                if (earlyboundconfig.oneTypePerFile)
-                {
-                    _trace.WriteLine("oneTypePerFile=true : Splitting types into separate files...");
-                    SplitCrmSvcUtilOutputFileIntoOneFilePerType(
-                        Path.Combine(_folder, earlyboundconfig.filename),
-                        Path.Combine(_folder, Path.GetDirectoryName(earlyboundconfig.filename)),
-                        earlyboundconfig.classNamespace);
-                }
-            }
+            return crmSvcUtilPath;
         }
 
-        private void Proc_OutputDataReceived(object sender, DataReceivedEventArgs e)
-        {
-            _trace.WriteLine(e.Data);
-        }
-
-        private void SplitCrmSvcUtilOutputFileIntoOneFilePerType(string earlyboundconfigFilename, string destinationDirectoryPath, string typeNamespace)
-        {
-            var sourceCode = File.ReadAllText(earlyboundconfigFilename);
-
-            var sourceCodeManipulator = new SourceCodeSplitter(_trace);
-            sourceCodeManipulator.WriteToSeparateFiles(destinationDirectoryPath, sourceCode, typeNamespace);
-        }
+        //private void Proc_OutputDataReceived(object sender, DataReceivedEventArgs e)
+        //{
+        //    _trace.WriteLine(e.Data);
+        //}
     }
 }

--- a/spkl/SparkleXrm.Tasks/packages.config
+++ b/spkl/SparkleXrm.Tasks/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="DLaB.Xrm.EarlyBoundGenerator.Api" version="1.2020.5.5" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.5" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.CoreTools" version="9.0.0.7" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.0.5" targetFramework="net462" />

--- a/spkl/spkl.sln
+++ b/spkl/spkl.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SparkleXrm.Tasks", "SparkleXrm.Tasks\SparkleXrm.Tasks.csproj", "{439FFD12-81E6-41DD-8AED-35A526051D45}"
 EndProject
@@ -36,8 +36,6 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Webresources", "Webresource
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "spkl", "spkl\spkl.csproj", "{CADC1BD4-46B5-46D9-B2CC-28482B7B90C5}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CrmSvcUtil.FilteringService", "CrmSvcUtilFilteringService\CrmSvcUtil.FilteringService.csproj", "{EA2B393E-2C0E-4F80-A44C-712877A04870}"
 EndProject
 Project("{F5034706-568F-408A-B7B3-4D38C6DB8A32}") = "BuildTasks", "BuildTasks\BuildTasks.pssproj", "{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}"
 EndProject
@@ -97,14 +95,6 @@ Global
 		{CADC1BD4-46B5-46D9-B2CC-28482B7B90C5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CADC1BD4-46B5-46D9-B2CC-28482B7B90C5}.Release|x86.ActiveCfg = Release|Any CPU
 		{CADC1BD4-46B5-46D9-B2CC-28482B7B90C5}.Release|x86.Build.0 = Release|Any CPU
-		{EA2B393E-2C0E-4F80-A44C-712877A04870}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EA2B393E-2C0E-4F80-A44C-712877A04870}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EA2B393E-2C0E-4F80-A44C-712877A04870}.Debug|x86.ActiveCfg = Debug|x86
-		{EA2B393E-2C0E-4F80-A44C-712877A04870}.Debug|x86.Build.0 = Debug|x86
-		{EA2B393E-2C0E-4F80-A44C-712877A04870}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EA2B393E-2C0E-4F80-A44C-712877A04870}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EA2B393E-2C0E-4F80-A44C-712877A04870}.Release|x86.ActiveCfg = Release|x86
-		{EA2B393E-2C0E-4F80-A44C-712877A04870}.Release|x86.Build.0 = Release|x86
 		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Debug|x86.ActiveCfg = Debug|Any CPU

--- a/spkl/spkl/App.config
+++ b/spkl/spkl/App.config
@@ -70,6 +70,10 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
      
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.19.8.16603" newVersion="3.19.8.16603" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/spkl/spkl/packages.config
+++ b/spkl/spkl/packages.config
@@ -1,18 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CmdLine" version="1.0.7.509" targetFramework="net452" />
+  <package id="DLaB.Xrm.EarlyBoundGenerator.Api" version="1.2020.5.5" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.7" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.CoreTools" version="9.0.0.7" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.0.7" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.0.7" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.0.7" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.22.302111727" targetFramework="net462" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net462" />
   <package id="System.Net.Http" version="4.3.3" targetFramework="net462" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net462" />
-  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net462" />
-  <package id="System.Runtime" version="4.3.0" targetFramework="net462" />
-  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net462" />
 </packages>

--- a/spkl/spkl/spkl.csproj
+++ b/spkl/spkl/spkl.csproj
@@ -38,6 +38,9 @@
       <HintPath>..\packages\CmdLine.1.0.7.509\lib\net40-Client\CmdLine.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="DLaB.EarlyBoundGenerator.Api, Version=1.2020.5.5, Culture=neutral, PublicKeyToken=915c5118a4c943b9, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.EarlyBoundGenerator.Api.1.2020.5.5\lib\net462\DLaB.EarlyBoundGenerator.Api.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.0.7\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
@@ -53,6 +56,7 @@
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.22.302111727\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.0.7\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
@@ -80,6 +84,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
@@ -141,6 +146,14 @@
     <None Include="bin\Debug\spkl.crmsvcutil.config" />
     <None Include="bin\Debug\spkl.CrmSvcUtilExtensions.dll.config" />
     <None Include="bin\Debug\spkl.exe.config" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1031.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1036.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1040.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1044.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1045.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1049.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\alphabets\1058.json" />
+    <None Include="bin\DLaB.EarlyBoundGenerator\CrmSvcUtil.exe.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
@@ -160,10 +173,6 @@
     <None Include="Package\spkl\unpack.bat" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CrmSvcUtilFilteringService\CrmSvcUtil.FilteringService.csproj">
-      <Project>{ea2b393e-2c0e-4f80-a44c-712877a04870}</Project>
-      <Name>CrmSvcUtil.FilteringService</Name>
-    </ProjectReference>
     <ProjectReference Include="..\SparkleXrm.Tasks\SparkleXrm.Tasks.csproj">
       <Project>{439ffd12-81e6-41dd-8aed-35a526051d45}</Project>
       <Name>SparkleXrm.Tasks</Name>
@@ -212,6 +221,21 @@
     <Content Include="bin\Debug\spkl.CrmSvcUtilExtensions.pdb" />
     <Content Include="bin\Debug\spkl.exe" />
     <Content Include="bin\Debug\spkl.pdb" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\CrmSvcUtil.exe" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\DLaB.CrmSvcUtilExtensions.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Crm.Sdk.Proxy.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Rest.ClientRuntime.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Client.CodeGeneration.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Client.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Sdk.Deployment.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Sdk.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.Connector.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.CrmConnectControl.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.Ui.Styles.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Microsoft.Xrm.Tooling.WebResourceUtility.dll" />
+    <Content Include="bin\DLaB.EarlyBoundGenerator\Newtonsoft.Json.dll" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="bin\Release\" />


### PR DESCRIPTION
PR for Integrate EarlyBound Generator #378

Removed Previous CrmSvcUtil Utilities.
Mapped all settings of earlyboundtypes except generateStateEnums and GenerateGlobalOptionSets.   There are no settings currently for this in the EarlyBoundGenerator, and I can't think of a good reason why you would not want to include these.

Updated EarlyBoundTypeConfig to inherit from DLaB.EarlyBoundGeneator.Settings.POCO.ExtensionConfig.  This means all settings in the EarlyBoundGenerator will be allowed (except it they are overriden with the current settings of the EarlyBoundTypeConfig.  Also added names for the action, and optionSet.

Updated Tests.

Updated VS.  Not sure that matters...