### PR TITLE
🧪 Support registering custom api plugin

### DIFF
--- a/spkl/SparkleXrm.Tasks.Tests/CustomApiTest.cs
+++ b/spkl/SparkleXrm.Tasks.Tests/CustomApiTest.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Microsoft.Xrm.Tooling.Connector;
+using System;
+using System.Configuration;
+using System.IO;
+
+namespace SparkleXrm.Tasks.Tests
+{
+    [TestClass]
+    public class CustomApiTest
+    {
+        [TestMethod]
+        [TestCategory("Integration Tests")]
+        public void DeployCustomApi()
+        {
+            CrmServiceClient crmSvc = new CrmServiceClient(ConfigurationManager.ConnectionStrings["integration_testing"].ConnectionString);
+            var userId = crmSvc.GetMyCrmUserId();
+            var trace = new TraceLogger();
+           
+
+            // Check if the API exists
+            var fetchQuery = @"<fetch top='50' >
+                              <entity name='customapi' >
+                                <filter>
+                                  <condition attribute='uniquename' operator='eq' value='spkl_CustomApiTest' />
+                                </filter>
+                              </entity>
+                            </fetch>";
+
+            var existing = crmSvc.RetrieveMultiple(new FetchExpression(fetchQuery));
+            if (existing.Entities.Count == 0)
+            {
+                // Create custom API
+                var customApi = new Entity("customapi")
+                {
+                    Attributes = {
+                { "allowedcustomprocessingsteptype", new OptionSetValue(0)}, //None
+                { "bindingtype", new OptionSetValue(0)}, //Global
+                { "description","Integration test for spkl" },
+                { "displayname","Custom API Example" },
+                { "executeprivilegename", null },
+                { "isfunction", false},
+                { "isprivate", false},
+                { "name","spkl_CustomApiTest"},
+                { "uniquename","spkl_CustomApiTest"}
+            }
+                };
+
+                Guid customApiId = crmSvc.Create(customApi);
+            }
+        }
+    }
+}

--- a/spkl/SparkleXrm.Tasks.Tests/SparkleXrm.Tasks.Tests.csproj
+++ b/spkl/SparkleXrm.Tasks.Tests/SparkleXrm.Tasks.Tests.csproj
@@ -162,6 +162,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="CustomApiTest.cs" />
     <Compile Include="DeployPluginAndWorkflowTests.cs" />
     <Compile Include="DeployPluginTests.cs" />
     <Compile Include="DownloadWebresourceFiles.cs" />

--- a/spkl/SparkleXrm.Tasks/CrmPluginRegistrationAttribute.cs
+++ b/spkl/SparkleXrm.Tasks/CrmPluginRegistrationAttribute.cs
@@ -4,6 +4,16 @@ using System;
 [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
 public class CrmPluginRegistrationAttribute : Attribute
 {
+    /// <summary>
+    /// Constructor for Custom Api registration - only unique name of the api is required
+    /// </summary>
+    /// <param name="message"></param>
+    public CrmPluginRegistrationAttribute(
+    string message)
+    {
+        Message = message;
+        IsolationMode = IsolationModeEnum.Sandbox;
+    }
 
     public CrmPluginRegistrationAttribute(
         string message,

--- a/spkl/SparkleXrm.Tasks/CustomAttributeDataEx.cs
+++ b/spkl/SparkleXrm.Tasks/CustomAttributeDataEx.cs
@@ -48,7 +48,14 @@ namespace SparkleXrm.Tasks
                 (IsolationModeEnum)Enum.ToObject(typeof(IsolationModeEnum), (int)arguments[4].Value)
                 );
             }
-
+            else if (data.ConstructorArguments.Count == 1 && data.ConstructorArguments[0].ArgumentType.Name == "String")
+            {
+                // Custom Api Registration
+                attribute = new CrmPluginRegistrationAttribute(
+                (string)arguments[0].Value
+                );
+               
+            }
             foreach (var namedArgument in data.NamedArguments)
             {
                 switch (namedArgument.MemberName)

--- a/spkl/SparkleXrm.Tasks/EntitiesTrim.cs
+++ b/spkl/SparkleXrm.Tasks/EntitiesTrim.cs
@@ -12,6113 +12,7471 @@
 
 namespace SparkleXrm.Tasks
 {
-
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum pluginassembly_isolationmode
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        None = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Sandbox = 2,
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum pluginassembly_sourcetype
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Database = 0,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Disk = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Normal = 2,
-    }
-
-    /// <summary>
-    /// Assembly that contains one or more plug-in types.
-    /// </summary>
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("pluginassembly")]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class PluginAssembly : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
-    {
-
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        public PluginAssembly() :
-                base(EntityLogicalName)
-        {
-        }
-
-        public const string EntityLogicalName = "pluginassembly";
-
-        public const int EntityTypeCode = 4605;
-
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
-        public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        private void OnPropertyChanging(string propertyName)
-        {
-            if ((this.PropertyChanging != null))
-            {
-                this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
-        public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
-            }
-        }
-
-        /// <summary>
-        /// Bytes of the assembly, in Base64 format.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("content")]
-        public string Content
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("content");
-            }
-            set
-            {
-                this.OnPropertyChanging("Content");
-                this.SetAttributeValue("content", value);
-                this.OnPropertyChanged("Content");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who created the plug-in assembly.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the plug-in assembly was created.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
-        public System.Nullable<System.DateTime> CreatedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who created the pluginassembly.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Culture code for the plug-in assembly.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("culture")]
-        public string Culture
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("culture");
-            }
-            set
-            {
-                this.OnPropertyChanging("Culture");
-                this.SetAttributeValue("culture", value);
-                this.OnPropertyChanged("Culture");
-            }
-        }
-
-        /// <summary>
-        /// Customization Level.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
-        public System.Nullable<int> CustomizationLevel
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
-            }
-        }
-
-        /// <summary>
-        /// Description of the plug-in assembly.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
-        public string Description
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("description");
-            }
-            set
-            {
-                this.OnPropertyChanging("Description");
-                this.SetAttributeValue("description", value);
-                this.OnPropertyChanged("Description");
-            }
-        }
-
-        /// <summary>
-        /// Version in which the form is introduced.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
-        public string IntroducedVersion
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("introducedversion");
-            }
-            set
-            {
-                this.OnPropertyChanging("IntroducedVersion");
-                this.SetAttributeValue("introducedversion", value);
-                this.OnPropertyChanged("IntroducedVersion");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this component can be customized.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomizable")]
-        public Microsoft.Xrm.Sdk.BooleanManagedProperty IsCustomizable
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("iscustomizable");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsCustomizable");
-                this.SetAttributeValue("iscustomizable", value);
-                this.OnPropertyChanged("IsCustomizable");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this component should be hidden.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ishidden")]
-        public Microsoft.Xrm.Sdk.BooleanManagedProperty IsHidden
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("ishidden");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsHidden");
-                this.SetAttributeValue("ishidden", value);
-                this.OnPropertyChanged("IsHidden");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this component is managed.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
-        public System.Nullable<bool> IsManaged
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
-            }
-        }
-
-        /// <summary>
-        /// Information about how the plugin assembly is to be isolated at execution time; None / Sandboxed.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isolationmode")]
-        public System.Nullable<SparkleXrm.Tasks.pluginassembly_isolationmode> IsolationMode
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("isolationmode");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.pluginassembly_isolationmode)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.pluginassembly_isolationmode), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("IsolationMode");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("isolationmode", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("isolationmode", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("IsolationMode");
-            }
-        }
-
-        /// <summary>
-        /// Major of the assembly version.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("major")]
-        public System.Nullable<int> Major
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("major");
-            }
-        }
-
-        /// <summary>
-        /// Minor of the assembly version.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("minor")]
-        public System.Nullable<int> Minor
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("minor");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who last modified the plug-in assembly.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the plug-in assembly was last modified.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
-        public System.Nullable<System.DateTime> ModifiedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who last modified the pluginassembly.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Name of the plug-in assembly.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
-        public string Name
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("name");
-            }
-            set
-            {
-                this.OnPropertyChanging("Name");
-                this.SetAttributeValue("name", value);
-                this.OnPropertyChanged("Name");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the organization with which the plug-in assembly is associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
-        public Microsoft.Xrm.Sdk.EntityReference OrganizationId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
-        public System.Nullable<System.DateTime> OverwriteTime
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
-            }
-        }
-
-        /// <summary>
-        /// File name of the plug-in assembly. Used when the source type is set to 1.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("path")]
-        public string Path
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("path");
-            }
-            set
-            {
-                this.OnPropertyChanging("Path");
-                this.SetAttributeValue("path", value);
-                this.OnPropertyChanged("Path");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the plug-in assembly.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pluginassemblyid")]
-        public System.Nullable<System.Guid> PluginAssemblyId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("pluginassemblyid");
-            }
-            set
-            {
-                this.OnPropertyChanging("PluginAssemblyId");
-                this.SetAttributeValue("pluginassemblyid", value);
-                if (value.HasValue)
-                {
-                    base.Id = value.Value;
-                }
-                else
-                {
-                    base.Id = System.Guid.Empty;
-                }
-                this.OnPropertyChanged("PluginAssemblyId");
-            }
-        }
-
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pluginassemblyid")]
-        public override System.Guid Id
-        {
-            get
-            {
-                return base.Id;
-            }
-            set
-            {
-                this.PluginAssemblyId = value;
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the plug-in assembly.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pluginassemblyidunique")]
-        public System.Nullable<System.Guid> PluginAssemblyIdUnique
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("pluginassemblyidunique");
-            }
-        }
-
-        /// <summary>
-        /// Public key token of the assembly. This value can be obtained from the assembly by using reflection.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("publickeytoken")]
-        public string PublicKeyToken
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("publickeytoken");
-            }
-            set
-            {
-                this.OnPropertyChanging("PublicKeyToken");
-                this.SetAttributeValue("publickeytoken", value);
-                this.OnPropertyChanged("PublicKeyToken");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the associated solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
-        public System.Nullable<System.Guid> SolutionId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
-            }
-        }
-
-        /// <summary>
-        /// Hash of the source of the assembly.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sourcehash")]
-        public string SourceHash
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("sourcehash");
-            }
-            set
-            {
-                this.OnPropertyChanging("SourceHash");
-                this.SetAttributeValue("sourcehash", value);
-                this.OnPropertyChanged("SourceHash");
-            }
-        }
-
-        /// <summary>
-        /// Location of the assembly, for example 0=database, 1=on-disk.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sourcetype")]
-        public System.Nullable<SparkleXrm.Tasks.pluginassembly_sourcetype> SourceType
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("sourcetype");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.pluginassembly_sourcetype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.pluginassembly_sourcetype), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("SourceType");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("sourcetype", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("sourcetype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("SourceType");
-            }
-        }
-
-        /// <summary>
-        /// Version number of the assembly. The value can be obtained from the assembly through reflection.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("version")]
-        public string Version
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("version");
-            }
-            set
-            {
-                this.OnPropertyChanging("Version");
-                this.SetAttributeValue("version", value);
-                this.OnPropertyChanged("Version");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
-        public System.Nullable<long> VersionNumber
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
-            }
-        }
-
-        /// <summary>
-        /// 1:N pluginassembly_plugintype
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("pluginassembly_plugintype")]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.PluginType> pluginassembly_plugintype
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.PluginType>("pluginassembly_plugintype", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("pluginassembly_plugintype");
-                this.SetRelatedEntities<SparkleXrm.Tasks.PluginType>("pluginassembly_plugintype", null, value);
-                this.OnPropertyChanged("pluginassembly_plugintype");
-            }
-        }
-    }
-
-    /// <summary>
-    /// Type that inherits from the IPlugin interface and is contained within a plug-in assembly.
-    /// </summary>
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("plugintype")]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class PluginType : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
-    {
-
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        public PluginType() :
-                base(EntityLogicalName)
-        {
-        }
-
-        public const string EntityLogicalName = "plugintype";
-
-        public const int EntityTypeCode = 4602;
-
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
-        public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        private void OnPropertyChanging(string propertyName)
-        {
-            if ((this.PropertyChanging != null))
-            {
-                this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// Full path name of the plug-in assembly.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("assemblyname")]
-        public string AssemblyName
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("assemblyname");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
-        public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who created the plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the plug-in type was created.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
-        public System.Nullable<System.DateTime> CreatedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who created the plugintype.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Culture code for the plug-in assembly.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("culture")]
-        public string Culture
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("culture");
-            }
-        }
-
-        /// <summary>
-        /// Customization level of the plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
-        public System.Nullable<int> CustomizationLevel
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
-            }
-        }
-
-        /// <summary>
-        /// Serialized Custom Activity Type information, including required arguments. For more information, see SandboxCustomActivityInfo.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customworkflowactivityinfo")]
-        public string CustomWorkflowActivityInfo
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("customworkflowactivityinfo");
-            }
-        }
-
-        /// <summary>
-        /// Description of the plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
-        public string Description
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("description");
-            }
-            set
-            {
-                this.OnPropertyChanging("Description");
-                this.SetAttributeValue("description", value);
-                this.OnPropertyChanged("Description");
-            }
-        }
-
-        /// <summary>
-        /// User friendly name for the plug-in.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("friendlyname")]
-        public string FriendlyName
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("friendlyname");
-            }
-            set
-            {
-                this.OnPropertyChanging("FriendlyName");
-                this.SetAttributeValue("friendlyname", value);
-                this.OnPropertyChanged("FriendlyName");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
-        public System.Nullable<bool> IsManaged
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
-            }
-        }
-
-        /// <summary>
-        /// Indicates if the plug-in is a custom activity for workflows.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isworkflowactivity")]
-        public System.Nullable<bool> IsWorkflowActivity
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("isworkflowactivity");
-            }
-            set
-            {
-                this.SetAttributeValue("isworkflowactivity", value);
-            }
-        }
-
-        /// <summary>
-        /// Major of the version number of the assembly for the plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("major")]
-        public System.Nullable<int> Major
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("major");
-            }
-        }
-
-        /// <summary>
-        /// Minor of the version number of the assembly for the plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("minor")]
-        public System.Nullable<int> Minor
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("minor");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who last modified the plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the plug-in type was last modified.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
-        public System.Nullable<System.DateTime> ModifiedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who last modified the plugintype.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Name of the plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
-        public string Name
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("name");
-            }
-            set
-            {
-                this.OnPropertyChanging("Name");
-                this.SetAttributeValue("name", value);
-                this.OnPropertyChanged("Name");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the organization with which the plug-in type is associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
-        public Microsoft.Xrm.Sdk.EntityReference OrganizationId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
-        public System.Nullable<System.DateTime> OverwriteTime
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the plug-in assembly that contains this plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pluginassemblyid")]
-        public Microsoft.Xrm.Sdk.EntityReference PluginAssemblyId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("pluginassemblyid");
-            }
-            set
-            {
-                this.OnPropertyChanging("PluginAssemblyId");
-                this.SetAttributeValue("pluginassemblyid", value);
-                this.OnPropertyChanged("PluginAssemblyId");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("plugintypeid")]
-        public System.Nullable<System.Guid> PluginTypeId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("plugintypeid");
-            }
-            set
-            {
-                this.OnPropertyChanging("PluginTypeId");
-                this.SetAttributeValue("plugintypeid", value);
-                if (value.HasValue)
-                {
-                    base.Id = value.Value;
-                }
-                else
-                {
-                    base.Id = System.Guid.Empty;
-                }
-                this.OnPropertyChanged("PluginTypeId");
-            }
-        }
-
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("plugintypeid")]
-        public override System.Guid Id
-        {
-            get
-            {
-                return base.Id;
-            }
-            set
-            {
-                this.PluginTypeId = value;
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("plugintypeidunique")]
-        public System.Nullable<System.Guid> PluginTypeIdUnique
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("plugintypeidunique");
-            }
-        }
-
-        /// <summary>
-        /// Public key token of the assembly for the plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("publickeytoken")]
-        public string PublicKeyToken
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("publickeytoken");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the associated solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
-        public System.Nullable<System.Guid> SolutionId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
-            }
-        }
-
-        /// <summary>
-        /// Fully qualified type name of the plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("typename")]
-        public string TypeName
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("typename");
-            }
-            set
-            {
-                this.OnPropertyChanging("TypeName");
-                this.SetAttributeValue("typename", value);
-                this.OnPropertyChanged("TypeName");
-            }
-        }
-
-        /// <summary>
-        /// Version number of the assembly for the plug-in type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("version")]
-        public string Version
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("version");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
-        public System.Nullable<long> VersionNumber
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
-            }
-        }
-
-        /// <summary>
-        /// Group name of workflow custom activity.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("workflowactivitygroupname")]
-        public string WorkflowActivityGroupName
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("workflowactivitygroupname");
-            }
-            set
-            {
-                this.OnPropertyChanging("WorkflowActivityGroupName");
-                this.SetAttributeValue("workflowactivitygroupname", value);
-                this.OnPropertyChanged("WorkflowActivityGroupName");
-            }
-        }
-
-        /// <summary>
-        /// 1:N plugintype_sdkmessageprocessingstep
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("plugintype_sdkmessageprocessingstep")]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStep> plugintype_sdkmessageprocessingstep
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("plugintype_sdkmessageprocessingstep", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("plugintype_sdkmessageprocessingstep");
-                this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("plugintype_sdkmessageprocessingstep", null, value);
-                this.OnPropertyChanged("plugintype_sdkmessageprocessingstep");
-            }
-        }
-
-        /// <summary>
-        /// 1:N plugintypeid_sdkmessageprocessingstep
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("plugintypeid_sdkmessageprocessingstep")]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStep> plugintypeid_sdkmessageprocessingstep
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("plugintypeid_sdkmessageprocessingstep", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("plugintypeid_sdkmessageprocessingstep");
-                this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("plugintypeid_sdkmessageprocessingstep", null, value);
-                this.OnPropertyChanged("plugintypeid_sdkmessageprocessingstep");
-            }
-        }
-
-        /// <summary>
-        /// N:1 pluginassembly_plugintype
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pluginassemblyid")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("pluginassembly_plugintype")]
-        public SparkleXrm.Tasks.PluginAssembly pluginassembly_plugintype
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.PluginAssembly>("pluginassembly_plugintype", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("pluginassembly_plugintype");
-                this.SetRelatedEntity<SparkleXrm.Tasks.PluginAssembly>("pluginassembly_plugintype", null, value);
-                this.OnPropertyChanged("pluginassembly_plugintype");
-            }
-        }
-    }
-
-    /// <summary>
-    /// Message that is supported by the SDK.
-    /// </summary>
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("sdkmessage")]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class SdkMessage : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
-    {
-
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        public SdkMessage() :
-                base(EntityLogicalName)
-        {
-        }
-
-        public const string EntityLogicalName = "sdkmessage";
-
-        public const int EntityTypeCode = 4606;
-
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
-        public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        private void OnPropertyChanging(string propertyName)
-        {
-            if ((this.PropertyChanging != null))
-            {
-                this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// Information about whether the SDK message is automatically transacted.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("autotransact")]
-        public System.Nullable<bool> AutoTransact
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("autotransact");
-            }
-            set
-            {
-                this.OnPropertyChanging("AutoTransact");
-                this.SetAttributeValue("autotransact", value);
-                this.OnPropertyChanged("AutoTransact");
-            }
-        }
-
-        /// <summary>
-        /// Identifies where a method will be exposed. 0 - Server, 1 - Client, 2 - both.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("availability")]
-        public System.Nullable<int> Availability
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("availability");
-            }
-            set
-            {
-                this.OnPropertyChanging("Availability");
-                this.SetAttributeValue("availability", value);
-                this.OnPropertyChanged("Availability");
-            }
-        }
-
-        /// <summary>
-        /// If this is a categorized method, this is the name, otherwise None.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("categoryname")]
-        public string CategoryName
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("categoryname");
-            }
-            set
-            {
-                this.OnPropertyChanging("CategoryName");
-                this.SetAttributeValue("categoryname", value);
-                this.OnPropertyChanged("CategoryName");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who created the SDK message.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the SDK message was created.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
-        public System.Nullable<System.DateTime> CreatedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who created the sdkmessage.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Customization level of the SDK message.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
-        public System.Nullable<int> CustomizationLevel
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
-            }
-        }
-
-        /// <summary>
-        /// Indicates whether the SDK message should have its requests expanded per primary entity defined in its filters.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("expand")]
-        public System.Nullable<bool> Expand
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("expand");
-            }
-            set
-            {
-                this.OnPropertyChanging("Expand");
-                this.SetAttributeValue("expand", value);
-                this.OnPropertyChanged("Expand");
-            }
-        }
-
-        /// <summary>
-        /// Information about whether the SDK message is active.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isactive")]
-        public System.Nullable<bool> IsActive
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("isactive");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsActive");
-                this.SetAttributeValue("isactive", value);
-                this.OnPropertyChanged("IsActive");
-            }
-        }
-
-        /// <summary>
-        /// Indicates whether the SDK message is private.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isprivate")]
-        public System.Nullable<bool> IsPrivate
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("isprivate");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsPrivate");
-                this.SetAttributeValue("isprivate", value);
-                this.OnPropertyChanged("IsPrivate");
-            }
-        }
-
-        /// <summary>
-        /// Identifies whether an SDK message will be ReadOnly or Read Write. false - ReadWrite, true - ReadOnly .
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isreadonly")]
-        public System.Nullable<bool> IsReadOnly
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("isreadonly");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsReadOnly");
-                this.SetAttributeValue("isreadonly", value);
-                this.OnPropertyChanged("IsReadOnly");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isvalidforexecuteasync")]
-        public System.Nullable<bool> IsValidForExecuteAsync
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("isvalidforexecuteasync");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who last modified the SDK message.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the SDK message was last modified.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
-        public System.Nullable<System.DateTime> ModifiedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who last modified the sdkmessage.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Name of the SDK message.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
-        public string Name
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("name");
-            }
-            set
-            {
-                this.OnPropertyChanging("Name");
-                this.SetAttributeValue("name", value);
-                this.OnPropertyChanged("Name");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the organization with which the SDK message is associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
-        public Microsoft.Xrm.Sdk.EntityReference OrganizationId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message entity.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
-        public System.Nullable<System.Guid> SdkMessageId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageid");
-            }
-            set
-            {
-                this.OnPropertyChanging("SdkMessageId");
-                this.SetAttributeValue("sdkmessageid", value);
-                if (value.HasValue)
-                {
-                    base.Id = value.Value;
-                }
-                else
-                {
-                    base.Id = System.Guid.Empty;
-                }
-                this.OnPropertyChanged("SdkMessageId");
-            }
-        }
-
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
-        public override System.Guid Id
-        {
-            get
-            {
-                return base.Id;
-            }
-            set
-            {
-                this.SdkMessageId = value;
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageidunique")]
-        public System.Nullable<System.Guid> SdkMessageIdUnique
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageidunique");
-            }
-        }
-
-        /// <summary>
-        /// Indicates whether the SDK message is a template.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("template")]
-        public System.Nullable<bool> Template
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("template");
-            }
-            set
-            {
-                this.OnPropertyChanging("Template");
-                this.SetAttributeValue("template", value);
-                this.OnPropertyChanged("Template");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("throttlesettings")]
-        public string ThrottleSettings
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("throttlesettings");
-            }
-        }
-
-        /// <summary>
-        /// Number that identifies a specific revision of the SDK message. 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
-        public System.Nullable<long> VersionNumber
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
-            }
-        }
-
-        /// <summary>
-        /// Whether or not the SDK message can be called from a workflow.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("workflowsdkstepenabled")]
-        public System.Nullable<bool> WorkflowSdkStepEnabled
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("workflowsdkstepenabled");
-            }
-        }
-
-        /// <summary>
-        /// 1:N message_sdkmessagepair
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("message_sdkmessagepair")]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessagePair> message_sdkmessagepair
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessagePair>("message_sdkmessagepair", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("message_sdkmessagepair");
-                this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessagePair>("message_sdkmessagepair", null, value);
-                this.OnPropertyChanged("message_sdkmessagepair");
-            }
-        }
-
-        /// <summary>
-        /// 1:N sdkmessageid_sdkmessagefilter
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageid_sdkmessagefilter")]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageFilter> sdkmessageid_sdkmessagefilter
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageFilter>("sdkmessageid_sdkmessagefilter", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("sdkmessageid_sdkmessagefilter");
-                this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageFilter>("sdkmessageid_sdkmessagefilter", null, value);
-                this.OnPropertyChanged("sdkmessageid_sdkmessagefilter");
-            }
-        }
-
-        /// <summary>
-        /// 1:N sdkmessageid_sdkmessageprocessingstep
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageid_sdkmessageprocessingstep")]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStep> sdkmessageid_sdkmessageprocessingstep
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessageid_sdkmessageprocessingstep", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("sdkmessageid_sdkmessageprocessingstep");
-                this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessageid_sdkmessageprocessingstep", null, value);
-                this.OnPropertyChanged("sdkmessageid_sdkmessageprocessingstep");
-            }
-        }
-    }
-
-    /// <summary>
-    /// Filter that defines which SDK messages are valid for each type of entity.
-    /// </summary>
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("sdkmessagefilter")]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class SdkMessageFilter : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
-    {
-
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        public SdkMessageFilter() :
-                base(EntityLogicalName)
-        {
-        }
-
-        public const string EntityLogicalName = "sdkmessagefilter";
-
-        public const int EntityTypeCode = 4607;
-
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
-        public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        private void OnPropertyChanging(string propertyName)
-        {
-            if ((this.PropertyChanging != null))
-            {
-                this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// Identifies where a method will be exposed. 0 - Server, 1 - Client, 2 - both.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("availability")]
-        public System.Nullable<int> Availability
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("availability");
-            }
-            set
-            {
-                this.OnPropertyChanging("Availability");
-                this.SetAttributeValue("availability", value);
-                this.OnPropertyChanged("Availability");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who created the SDK message filter.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the SDK message filter was created.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
-        public System.Nullable<System.DateTime> CreatedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who created the sdkmessagefilter.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Customization level of the SDK message filter.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
-        public System.Nullable<int> CustomizationLevel
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
-            }
-        }
-
-        /// <summary>
-        /// Indicates whether a custom SDK message processing step is allowed.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomprocessingstepallowed")]
-        public System.Nullable<bool> IsCustomProcessingStepAllowed
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("iscustomprocessingstepallowed");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsCustomProcessingStepAllowed");
-                this.SetAttributeValue("iscustomprocessingstepallowed", value);
-                this.OnPropertyChanged("IsCustomProcessingStepAllowed");
-            }
-        }
-
-        /// <summary>
-        /// Indicates whether the filter should be visible.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isvisible")]
-        public System.Nullable<bool> IsVisible
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("isvisible");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who last modified the SDK message filter.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the SDK message filter was last modified.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
-        public System.Nullable<System.DateTime> ModifiedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who last modified the sdkmessagefilter.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the organization with which the SDK message filter is associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
-        public Microsoft.Xrm.Sdk.EntityReference OrganizationId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
-            }
-        }
-
-        /// <summary>
-        /// Type of entity with which the SDK message filter is primarily associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("primaryobjecttypecode")]
-        public string PrimaryObjectTypeCode
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("primaryobjecttypecode");
-            }
-            set
-            {
-                this.OnPropertyChanging("PrimaryObjectTypeCode");
-                this.SetAttributeValue("primaryobjecttypecode", value);
-                this.OnPropertyChanged("PrimaryObjectTypeCode");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message filter entity.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagefilterid")]
-        public System.Nullable<System.Guid> SdkMessageFilterId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessagefilterid");
-            }
-            set
-            {
-                this.OnPropertyChanging("SdkMessageFilterId");
-                this.SetAttributeValue("sdkmessagefilterid", value);
-                if (value.HasValue)
-                {
-                    base.Id = value.Value;
-                }
-                else
-                {
-                    base.Id = System.Guid.Empty;
-                }
-                this.OnPropertyChanged("SdkMessageFilterId");
-            }
-        }
-
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagefilterid")]
-        public override System.Guid Id
-        {
-            get
-            {
-                return base.Id;
-            }
-            set
-            {
-                this.SdkMessageFilterId = value;
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message filter.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagefilteridunique")]
-        public System.Nullable<System.Guid> SdkMessageFilterIdUnique
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessagefilteridunique");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the related SDK message.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
-        public Microsoft.Xrm.Sdk.EntityReference SdkMessageId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessageid");
-            }
-            set
-            {
-                this.OnPropertyChanging("SdkMessageId");
-                this.SetAttributeValue("sdkmessageid", value);
-                this.OnPropertyChanged("SdkMessageId");
-            }
-        }
-
-        /// <summary>
-        /// Type of entity with which the SDK message filter is secondarily associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("secondaryobjecttypecode")]
-        public string SecondaryObjectTypeCode
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("secondaryobjecttypecode");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
-        public System.Nullable<long> VersionNumber
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
-            }
-        }
-
-        /// <summary>
-        /// Whether or not the SDK message can be called from a workflow.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("workflowsdkstepenabled")]
-        public System.Nullable<bool> WorkflowSdkStepEnabled
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("workflowsdkstepenabled");
-            }
-        }
-
-        /// <summary>
-        /// 1:N sdkmessagefilterid_sdkmessageprocessingstep
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessagefilterid_sdkmessageprocessingstep")]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStep> sdkmessagefilterid_sdkmessageprocessingstep
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessagefilterid_sdkmessageprocessingstep", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("sdkmessagefilterid_sdkmessageprocessingstep");
-                this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessagefilterid_sdkmessageprocessingstep", null, value);
-                this.OnPropertyChanged("sdkmessagefilterid_sdkmessageprocessingstep");
-            }
-        }
-
-        /// <summary>
-        /// N:1 sdkmessageid_sdkmessagefilter
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageid_sdkmessagefilter")]
-        public SparkleXrm.Tasks.SdkMessage sdkmessageid_sdkmessagefilter
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessage>("sdkmessageid_sdkmessagefilter", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("sdkmessageid_sdkmessagefilter");
-                this.SetRelatedEntity<SparkleXrm.Tasks.SdkMessage>("sdkmessageid_sdkmessagefilter", null, value);
-                this.OnPropertyChanged("sdkmessageid_sdkmessagefilter");
-            }
-        }
-    }
-
-    /// <summary>
-    /// For internal use only.
-    /// </summary>
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("sdkmessagepair")]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class SdkMessagePair : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
-    {
-
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        public SdkMessagePair() :
-                base(EntityLogicalName)
-        {
-        }
-
-        public const string EntityLogicalName = "sdkmessagepair";
-
-        public const int EntityTypeCode = 4613;
-
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
-        public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        private void OnPropertyChanging(string propertyName)
-        {
-            if ((this.PropertyChanging != null))
-            {
-                this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who created the SDK message pair.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the SDK message pair was created.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
-        public System.Nullable<System.DateTime> CreatedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who created the sdkmessagepair.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Customization level of the SDK message filter.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
-        public System.Nullable<int> CustomizationLevel
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
-            }
-        }
-
-        /// <summary>
-        /// Endpoint that the message pair is associated with.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("endpoint")]
-        public string Endpoint
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("endpoint");
-            }
-            set
-            {
-                this.OnPropertyChanging("Endpoint");
-                this.SetAttributeValue("endpoint", value);
-                this.OnPropertyChanged("Endpoint");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who last modified the SDK message pair.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the SDK message pair was last modified.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
-        public System.Nullable<System.DateTime> ModifiedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who last modified the sdkmessagepair.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Namespace that the message pair is associated with.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("namespace")]
-        public string Namespace
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("namespace");
-            }
-            set
-            {
-                this.OnPropertyChanging("Namespace");
-                this.SetAttributeValue("namespace", value);
-                this.OnPropertyChanged("Namespace");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the organization with which the SDK message pair is associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
-        public Microsoft.Xrm.Sdk.EntityReference OrganizationId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagebindinginformation")]
-        public string SdkMessageBindingInformation
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("sdkmessagebindinginformation");
-            }
-            set
-            {
-                this.OnPropertyChanging("SdkMessageBindingInformation");
-                this.SetAttributeValue("sdkmessagebindinginformation", value);
-                this.OnPropertyChanged("SdkMessageBindingInformation");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the message with which the SDK message pair is associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
-        public Microsoft.Xrm.Sdk.EntityReference SdkMessageId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessageid");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message pair entity.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagepairid")]
-        public System.Nullable<System.Guid> SdkMessagePairId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessagepairid");
-            }
-            set
-            {
-                this.OnPropertyChanging("SdkMessagePairId");
-                this.SetAttributeValue("sdkmessagepairid", value);
-                if (value.HasValue)
-                {
-                    base.Id = value.Value;
-                }
-                else
-                {
-                    base.Id = System.Guid.Empty;
-                }
-                this.OnPropertyChanged("SdkMessagePairId");
-            }
-        }
-
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagepairid")]
-        public override System.Guid Id
-        {
-            get
-            {
-                return base.Id;
-            }
-            set
-            {
-                this.SdkMessagePairId = value;
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message pair.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagepairidunique")]
-        public System.Nullable<System.Guid> SdkMessagePairIdUnique
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessagepairidunique");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
-        public System.Nullable<long> VersionNumber
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
-            }
-        }
-
-        /// <summary>
-        /// N:1 message_sdkmessagepair
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("message_sdkmessagepair")]
-        public SparkleXrm.Tasks.SdkMessage message_sdkmessagepair
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessage>("message_sdkmessagepair", null);
-            }
-        }
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum sdkmessageprocessingstep_invocationsource
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Internal = -1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Parent = 0,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Child = 1,
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum sdkmessageprocessingstep_mode
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Synchronous = 0,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Asynchronous = 1,
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum sdkmessageprocessingstep_stage
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        InitialPreoperation_Forinternaluseonly = 5,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Prevalidation = 10,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        InternalPreoperationBeforeExternalPlugins_Forinternaluseonly = 15,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Preoperation = 20,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        InternalPreoperationAfterExternalPlugins_Forinternaluseonly = 25,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        MainOperation_Forinternaluseonly = 30,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        InternalPostoperationBeforeExternalPlugins_Forinternaluseonly = 35,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Postoperation = 40,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        InternalPostoperationAfterExternalPlugins_Forinternaluseonly = 45,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Postoperation_Deprecated = 50,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        FinalPostoperation_Forinternaluseonly = 55,
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum SdkMessageProcessingStepState
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Enabled = 0,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Disabled = 1,
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum sdkmessageprocessingstep_statuscode
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Enabled = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Disabled = 2,
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum sdkmessageprocessingstep_supporteddeployment
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        ServerOnly = 0,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        MicrosoftDynamics365ClientforOutlookOnly = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Both = 2,
-    }
-
-    /// <summary>
-    /// Stage in the execution pipeline that a plug-in is to execute.
-    /// </summary>
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("sdkmessageprocessingstep")]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class SdkMessageProcessingStep : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
-    {
-
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        public SdkMessageProcessingStep() :
-                base(EntityLogicalName)
-        {
-        }
-
-        public const string EntityLogicalName = "sdkmessageprocessingstep";
-
-        public const int EntityTypeCode = 4608;
-
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
-        public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        private void OnPropertyChanging(string propertyName)
-        {
-            if ((this.PropertyChanging != null))
-            {
-                this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// Indicates whether the asynchronous system job is automatically deleted on completion.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("asyncautodelete")]
-        public System.Nullable<bool> AsyncAutoDelete
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("asyncautodelete");
-            }
-            set
-            {
-                this.OnPropertyChanging("AsyncAutoDelete");
-                this.SetAttributeValue("asyncautodelete", value);
-                this.OnPropertyChanged("AsyncAutoDelete");
-            }
-        }
-
-        /// <summary>
-        /// Identifies whether a SDK Message Processing Step type will be ReadOnly or Read Write. false - ReadWrite, true - ReadOnly 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("canusereadonlyconnection")]
-        public System.Nullable<bool> CanUseReadOnlyConnection
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("canusereadonlyconnection");
-            }
-            set
-            {
-                this.OnPropertyChanging("CanUseReadOnlyConnection");
-                this.SetAttributeValue("canusereadonlyconnection", value);
-                this.OnPropertyChanged("CanUseReadOnlyConnection");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
-        public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
-            }
-        }
-
-        /// <summary>
-        /// Step-specific configuration for the plug-in type. Passed to the plug-in constructor at run time.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("configuration")]
-        public string Configuration
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("configuration");
-            }
-            set
-            {
-                this.OnPropertyChanging("Configuration");
-                this.SetAttributeValue("configuration", value);
-                this.OnPropertyChanged("Configuration");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who created the SDK message processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the SDK message processing step was created.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
-        public System.Nullable<System.DateTime> CreatedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who created the sdkmessageprocessingstep.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Customization level of the SDK message processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
-        public System.Nullable<int> CustomizationLevel
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
-            }
-        }
-
-        /// <summary>
-        /// Description of the SDK message processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
-        public string Description
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("description");
-            }
-            set
-            {
-                this.OnPropertyChanging("Description");
-                this.SetAttributeValue("description", value);
-                this.OnPropertyChanged("Description");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the associated event handler.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("eventhandler")]
-        public Microsoft.Xrm.Sdk.EntityReference EventHandler
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("eventhandler");
-            }
-            set
-            {
-                this.OnPropertyChanging("EventHandler");
-                this.SetAttributeValue("eventhandler", value);
-                this.OnPropertyChanged("EventHandler");
-            }
-        }
-
-        /// <summary>
-        /// Comma-separated list of attributes. If at least one of these attributes is modified, the plug-in should execute.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("filteringattributes")]
-        public string FilteringAttributes
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("filteringattributes");
-            }
-            set
-            {
-                this.OnPropertyChanging("FilteringAttributes");
-                this.SetAttributeValue("filteringattributes", value);
-                this.OnPropertyChanged("FilteringAttributes");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user to impersonate context when step is executed.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("impersonatinguserid")]
-        public Microsoft.Xrm.Sdk.EntityReference ImpersonatingUserId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("impersonatinguserid");
-            }
-            set
-            {
-                this.OnPropertyChanging("ImpersonatingUserId");
-                this.SetAttributeValue("impersonatinguserid", value);
-                this.OnPropertyChanged("ImpersonatingUserId");
-            }
-        }
-
-        /// <summary>
-        /// Version in which the form is introduced.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
-        public string IntroducedVersion
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("introducedversion");
-            }
-            set
-            {
-                this.OnPropertyChanging("IntroducedVersion");
-                this.SetAttributeValue("introducedversion", value);
-                this.OnPropertyChanged("IntroducedVersion");
-            }
-        }
-
-        /// <summary>
-        /// Identifies if a plug-in should be executed from a parent pipeline, a child pipeline, or both.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("invocationsource")]
-        [System.ObsoleteAttribute()]
-        public System.Nullable<SparkleXrm.Tasks.sdkmessageprocessingstep_invocationsource> InvocationSource
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("invocationsource");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.sdkmessageprocessingstep_invocationsource)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.sdkmessageprocessingstep_invocationsource), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("InvocationSource");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("invocationsource", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("invocationsource", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("InvocationSource");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this component can be customized.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomizable")]
-        public Microsoft.Xrm.Sdk.BooleanManagedProperty IsCustomizable
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("iscustomizable");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsCustomizable");
-                this.SetAttributeValue("iscustomizable", value);
-                this.OnPropertyChanged("IsCustomizable");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this component should be hidden.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ishidden")]
-        public Microsoft.Xrm.Sdk.BooleanManagedProperty IsHidden
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("ishidden");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsHidden");
-                this.SetAttributeValue("ishidden", value);
-                this.OnPropertyChanged("IsHidden");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this component is managed.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
-        public System.Nullable<bool> IsManaged
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
-            }
-        }
-
-        /// <summary>
-        /// Run-time mode of execution, for example, synchronous or asynchronous.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("mode")]
-        public System.Nullable<SparkleXrm.Tasks.sdkmessageprocessingstep_mode> Mode
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("mode");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.sdkmessageprocessingstep_mode)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.sdkmessageprocessingstep_mode), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("Mode");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("mode", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("mode", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("Mode");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who last modified the SDK message processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the SDK message processing step was last modified.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
-        public System.Nullable<System.DateTime> ModifiedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who last modified the sdkmessageprocessingstep.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Name of SdkMessage processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
-        public string Name
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("name");
-            }
-            set
-            {
-                this.OnPropertyChanging("Name");
-                this.SetAttributeValue("name", value);
-                this.OnPropertyChanged("Name");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the organization with which the SDK message processing step is associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
-        public Microsoft.Xrm.Sdk.EntityReference OrganizationId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
-        public System.Nullable<System.DateTime> OverwriteTime
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the plug-in type associated with the step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("plugintypeid")]
-        [System.ObsoleteAttribute()]
-        public Microsoft.Xrm.Sdk.EntityReference PluginTypeId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("plugintypeid");
-            }
-            set
-            {
-                this.OnPropertyChanging("PluginTypeId");
-                this.SetAttributeValue("plugintypeid", value);
-                this.OnPropertyChanged("PluginTypeId");
-            }
-        }
-
-        /// <summary>
-        /// Processing order within the stage.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("rank")]
-        public System.Nullable<int> Rank
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("rank");
-            }
-            set
-            {
-                this.OnPropertyChanging("Rank");
-                this.SetAttributeValue("rank", value);
-                this.OnPropertyChanged("Rank");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message filter.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagefilterid")]
-        public Microsoft.Xrm.Sdk.EntityReference SdkMessageFilterId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessagefilterid");
-            }
-            set
-            {
-                this.OnPropertyChanging("SdkMessageFilterId");
-                this.SetAttributeValue("sdkmessagefilterid", value);
-                this.OnPropertyChanged("SdkMessageFilterId");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
-        public Microsoft.Xrm.Sdk.EntityReference SdkMessageId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessageid");
-            }
-            set
-            {
-                this.OnPropertyChanging("SdkMessageId");
-                this.SetAttributeValue("sdkmessageid", value);
-                this.OnPropertyChanged("SdkMessageId");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message processing step entity.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepid")]
-        public System.Nullable<System.Guid> SdkMessageProcessingStepId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageprocessingstepid");
-            }
-            set
-            {
-                this.OnPropertyChanging("SdkMessageProcessingStepId");
-                this.SetAttributeValue("sdkmessageprocessingstepid", value);
-                if (value.HasValue)
-                {
-                    base.Id = value.Value;
-                }
-                else
-                {
-                    base.Id = System.Guid.Empty;
-                }
-                this.OnPropertyChanged("SdkMessageProcessingStepId");
-            }
-        }
-
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepid")]
-        public override System.Guid Id
-        {
-            get
-            {
-                return base.Id;
-            }
-            set
-            {
-                this.SdkMessageProcessingStepId = value;
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepidunique")]
-        public System.Nullable<System.Guid> SdkMessageProcessingStepIdUnique
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageprocessingstepidunique");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the Sdk message processing step secure configuration.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepsecureconfigid")]
-        public Microsoft.Xrm.Sdk.EntityReference SdkMessageProcessingStepSecureConfigId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessageprocessingstepsecureconfigid");
-            }
-            set
-            {
-                this.OnPropertyChanging("SdkMessageProcessingStepSecureConfigId");
-                this.SetAttributeValue("sdkmessageprocessingstepsecureconfigid", value);
-                this.OnPropertyChanged("SdkMessageProcessingStepSecureConfigId");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the associated solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
-        public System.Nullable<System.Guid> SolutionId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
-            }
-        }
-
-        /// <summary>
-        /// Stage in the execution pipeline that the SDK message processing step is in.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("stage")]
-        public System.Nullable<SparkleXrm.Tasks.sdkmessageprocessingstep_stage> Stage
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("stage");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.sdkmessageprocessingstep_stage)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.sdkmessageprocessingstep_stage), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("Stage");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("stage", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("stage", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("Stage");
-            }
-        }
-
-        /// <summary>
-        /// Status of the SDK message processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("statecode")]
-        public System.Nullable<SparkleXrm.Tasks.SdkMessageProcessingStepState> StateCode
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("statecode");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.SdkMessageProcessingStepState)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.SdkMessageProcessingStepState), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("StateCode");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("statecode", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("statecode", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("StateCode");
-            }
-        }
-
-        /// <summary>
-        /// Reason for the status of the SDK message processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("statuscode")]
-        public System.Nullable<SparkleXrm.Tasks.sdkmessageprocessingstep_statuscode> StatusCode
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("statuscode");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.sdkmessageprocessingstep_statuscode)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.sdkmessageprocessingstep_statuscode), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("StatusCode");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("statuscode", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("statuscode", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("StatusCode");
-            }
-        }
-
-        /// <summary>
-        /// Deployment that the SDK message processing step should be executed on; server, client, or both.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("supporteddeployment")]
-        public System.Nullable<SparkleXrm.Tasks.sdkmessageprocessingstep_supporteddeployment> SupportedDeployment
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("supporteddeployment");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.sdkmessageprocessingstep_supporteddeployment)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.sdkmessageprocessingstep_supporteddeployment), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("SupportedDeployment");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("supporteddeployment", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("supporteddeployment", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("SupportedDeployment");
-            }
-        }
-
-        /// <summary>
-        /// Number that identifies a specific revision of the SDK message processing step. 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
-        public System.Nullable<long> VersionNumber
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
-            }
-        }
-
-        /// <summary>
-        /// 1:N sdkmessageprocessingstepid_sdkmessageprocessingstepimage
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageprocessingstepid_sdkmessageprocessingstepimage")]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStepImage> sdkmessageprocessingstepid_sdkmessageprocessingstepimage
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStepImage>("sdkmessageprocessingstepid_sdkmessageprocessingstepimage", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("sdkmessageprocessingstepid_sdkmessageprocessingstepimage");
-                this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStepImage>("sdkmessageprocessingstepid_sdkmessageprocessingstepimage", null, value);
-                this.OnPropertyChanged("sdkmessageprocessingstepid_sdkmessageprocessingstepimage");
-            }
-        }
-
-        /// <summary>
-        /// N:1 plugintype_sdkmessageprocessingstep
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("eventhandler")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("plugintype_sdkmessageprocessingstep")]
-        public SparkleXrm.Tasks.PluginType plugintype_sdkmessageprocessingstep
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.PluginType>("plugintype_sdkmessageprocessingstep", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("plugintype_sdkmessageprocessingstep");
-                this.SetRelatedEntity<SparkleXrm.Tasks.PluginType>("plugintype_sdkmessageprocessingstep", null, value);
-                this.OnPropertyChanged("plugintype_sdkmessageprocessingstep");
-            }
-        }
-
-        /// <summary>
-        /// N:1 plugintypeid_sdkmessageprocessingstep
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("plugintypeid")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("plugintypeid_sdkmessageprocessingstep")]
-        public SparkleXrm.Tasks.PluginType plugintypeid_sdkmessageprocessingstep
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.PluginType>("plugintypeid_sdkmessageprocessingstep", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("plugintypeid_sdkmessageprocessingstep");
-                this.SetRelatedEntity<SparkleXrm.Tasks.PluginType>("plugintypeid_sdkmessageprocessingstep", null, value);
-                this.OnPropertyChanged("plugintypeid_sdkmessageprocessingstep");
-            }
-        }
-
-        /// <summary>
-        /// N:1 sdkmessagefilterid_sdkmessageprocessingstep
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagefilterid")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessagefilterid_sdkmessageprocessingstep")]
-        public SparkleXrm.Tasks.SdkMessageFilter sdkmessagefilterid_sdkmessageprocessingstep
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessageFilter>("sdkmessagefilterid_sdkmessageprocessingstep", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("sdkmessagefilterid_sdkmessageprocessingstep");
-                this.SetRelatedEntity<SparkleXrm.Tasks.SdkMessageFilter>("sdkmessagefilterid_sdkmessageprocessingstep", null, value);
-                this.OnPropertyChanged("sdkmessagefilterid_sdkmessageprocessingstep");
-            }
-        }
-
-        /// <summary>
-        /// N:1 sdkmessageid_sdkmessageprocessingstep
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageid_sdkmessageprocessingstep")]
-        public SparkleXrm.Tasks.SdkMessage sdkmessageid_sdkmessageprocessingstep
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessage>("sdkmessageid_sdkmessageprocessingstep", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("sdkmessageid_sdkmessageprocessingstep");
-                this.SetRelatedEntity<SparkleXrm.Tasks.SdkMessage>("sdkmessageid_sdkmessageprocessingstep", null, value);
-                this.OnPropertyChanged("sdkmessageid_sdkmessageprocessingstep");
-            }
-        }
-
-        /// <summary>
-        /// N:1 sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepsecureconfigid")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep")]
-        public SparkleXrm.Tasks.SdkMessageProcessingStepSecureConfig sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessageProcessingStepSecureConfig>("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep");
-                this.SetRelatedEntity<SparkleXrm.Tasks.SdkMessageProcessingStepSecureConfig>("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep", null, value);
-                this.OnPropertyChanged("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep");
-            }
-        }
-
-        /// <summary>
-        /// N:1 serviceendpoint_sdkmessageprocessingstep
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("eventhandler")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("serviceendpoint_sdkmessageprocessingstep")]
-        public SparkleXrm.Tasks.ServiceEndpoint serviceendpoint_sdkmessageprocessingstep
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.ServiceEndpoint>("serviceendpoint_sdkmessageprocessingstep", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("serviceendpoint_sdkmessageprocessingstep");
-                this.SetRelatedEntity<SparkleXrm.Tasks.ServiceEndpoint>("serviceendpoint_sdkmessageprocessingstep", null, value);
-                this.OnPropertyChanged("serviceendpoint_sdkmessageprocessingstep");
-            }
-        }
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum sdkmessageprocessingstepimage_imagetype
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        PreImage = 0,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        PostImage = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Both = 2,
-    }
-
-    /// <summary>
-    /// Copy of an entity's attributes before or after the core system operation.
-    /// </summary>
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("sdkmessageprocessingstepimage")]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class SdkMessageProcessingStepImage : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
-    {
-
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        public SdkMessageProcessingStepImage() :
-                base(EntityLogicalName)
-        {
-        }
-
-        public const string EntityLogicalName = "sdkmessageprocessingstepimage";
-
-        public const int EntityTypeCode = 4615;
-
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
-        public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        private void OnPropertyChanging(string propertyName)
-        {
-            if ((this.PropertyChanging != null))
-            {
-                this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// Comma-separated list of attributes that are to be passed into the SDK message processing step image.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("attributes")]
-        public string Attributes1
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("attributes");
-            }
-            set
-            {
-                this.OnPropertyChanging("Attributes1");
-                this.SetAttributeValue("attributes", value);
-                this.OnPropertyChanged("Attributes1");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
-        public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who created the SDK message processing step image.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the SDK message processing step image was created.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
-        public System.Nullable<System.DateTime> CreatedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who created the sdkmessageprocessingstepimage.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Customization level of the SDK message processing step image.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
-        public System.Nullable<int> CustomizationLevel
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
-            }
-        }
-
-        /// <summary>
-        /// Description of the SDK message processing step image.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
-        public string Description
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("description");
-            }
-            set
-            {
-                this.OnPropertyChanging("Description");
-                this.SetAttributeValue("description", value);
-                this.OnPropertyChanged("Description");
-            }
-        }
-
-        /// <summary>
-        /// Key name used to access the pre-image or post-image property bags in a step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("entityalias")]
-        public string EntityAlias
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("entityalias");
-            }
-            set
-            {
-                this.OnPropertyChanging("EntityAlias");
-                this.SetAttributeValue("entityalias", value);
-                this.OnPropertyChanged("EntityAlias");
-            }
-        }
-
-        /// <summary>
-        /// Type of image requested.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("imagetype")]
-        public System.Nullable<SparkleXrm.Tasks.sdkmessageprocessingstepimage_imagetype> ImageType
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("imagetype");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.sdkmessageprocessingstepimage_imagetype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.sdkmessageprocessingstepimage_imagetype), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("ImageType");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("imagetype", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("imagetype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("ImageType");
-            }
-        }
-
-        /// <summary>
-        /// Version in which the form is introduced.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
-        public string IntroducedVersion
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("introducedversion");
-            }
-            set
-            {
-                this.OnPropertyChanging("IntroducedVersion");
-                this.SetAttributeValue("introducedversion", value);
-                this.OnPropertyChanged("IntroducedVersion");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this component can be customized.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomizable")]
-        public Microsoft.Xrm.Sdk.BooleanManagedProperty IsCustomizable
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("iscustomizable");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsCustomizable");
-                this.SetAttributeValue("iscustomizable", value);
-                this.OnPropertyChanged("IsCustomizable");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
-        public System.Nullable<bool> IsManaged
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
-            }
-        }
-
-        /// <summary>
-        /// Name of the property on the Request message.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("messagepropertyname")]
-        public string MessagePropertyName
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("messagepropertyname");
-            }
-            set
-            {
-                this.OnPropertyChanging("MessagePropertyName");
-                this.SetAttributeValue("messagepropertyname", value);
-                this.OnPropertyChanged("MessagePropertyName");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who last modified the SDK message processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the SDK message processing step was last modified.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
-        public System.Nullable<System.DateTime> ModifiedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who last modified the sdkmessageprocessingstepimage.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Name of SdkMessage processing step image.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
-        public string Name
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("name");
-            }
-            set
-            {
-                this.OnPropertyChanging("Name");
-                this.SetAttributeValue("name", value);
-                this.OnPropertyChanged("Name");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the organization with which the SDK message processing step is associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
-        public Microsoft.Xrm.Sdk.EntityReference OrganizationId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
-        public System.Nullable<System.DateTime> OverwriteTime
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
-            }
-        }
-
-        /// <summary>
-        /// Name of the related entity.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("relatedattributename")]
-        public string RelatedAttributeName
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("relatedattributename");
-            }
-            set
-            {
-                this.OnPropertyChanging("RelatedAttributeName");
-                this.SetAttributeValue("relatedattributename", value);
-                this.OnPropertyChanged("RelatedAttributeName");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepid")]
-        public Microsoft.Xrm.Sdk.EntityReference SdkMessageProcessingStepId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessageprocessingstepid");
-            }
-            set
-            {
-                this.OnPropertyChanging("SdkMessageProcessingStepId");
-                this.SetAttributeValue("sdkmessageprocessingstepid", value);
-                this.OnPropertyChanged("SdkMessageProcessingStepId");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message processing step image entity.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepimageid")]
-        public System.Nullable<System.Guid> SdkMessageProcessingStepImageId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageprocessingstepimageid");
-            }
-            set
-            {
-                this.OnPropertyChanging("SdkMessageProcessingStepImageId");
-                this.SetAttributeValue("sdkmessageprocessingstepimageid", value);
-                if (value.HasValue)
-                {
-                    base.Id = value.Value;
-                }
-                else
-                {
-                    base.Id = System.Guid.Empty;
-                }
-                this.OnPropertyChanged("SdkMessageProcessingStepImageId");
-            }
-        }
-
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepimageid")]
-        public override System.Guid Id
-        {
-            get
-            {
-                return base.Id;
-            }
-            set
-            {
-                this.SdkMessageProcessingStepImageId = value;
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message processing step image.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepimageidunique")]
-        public System.Nullable<System.Guid> SdkMessageProcessingStepImageIdUnique
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageprocessingstepimageidunique");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the associated solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
-        public System.Nullable<System.Guid> SolutionId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
-            }
-        }
-
-        /// <summary>
-        /// Number that identifies a specific revision of the step image. 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
-        public System.Nullable<long> VersionNumber
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
-            }
-        }
-
-        /// <summary>
-        /// N:1 sdkmessageprocessingstepid_sdkmessageprocessingstepimage
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepid")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageprocessingstepid_sdkmessageprocessingstepimage")]
-        public SparkleXrm.Tasks.SdkMessageProcessingStep sdkmessageprocessingstepid_sdkmessageprocessingstepimage
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessageprocessingstepid_sdkmessageprocessingstepimage", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("sdkmessageprocessingstepid_sdkmessageprocessingstepimage");
-                this.SetRelatedEntity<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessageprocessingstepid_sdkmessageprocessingstepimage", null, value);
-                this.OnPropertyChanged("sdkmessageprocessingstepid_sdkmessageprocessingstepimage");
-            }
-        }
-    }
-
-    /// <summary>
-    /// Non-public custom configuration that is passed to a plug-in's constructor.
-    /// </summary>
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("sdkmessageprocessingstepsecureconfig")]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class SdkMessageProcessingStepSecureConfig : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
-    {
-
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        public SdkMessageProcessingStepSecureConfig() :
-                base(EntityLogicalName)
-        {
-        }
-
-        public const string EntityLogicalName = "sdkmessageprocessingstepsecureconfig";
-
-        public const int EntityTypeCode = 4616;
-
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
-        public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        private void OnPropertyChanging(string propertyName)
-        {
-            if ((this.PropertyChanging != null))
-            {
-                this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who created the SDK message processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the SDK message processing step was created.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
-        public System.Nullable<System.DateTime> CreatedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who created the sdkmessageprocessingstepsecureconfig.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Customization level of the SDK message processing step secure configuration.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
-        public System.Nullable<int> CustomizationLevel
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who last modified the SDK message processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the SDK message processing step was last modified.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
-        public System.Nullable<System.DateTime> ModifiedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who last modified the sdkmessageprocessingstepsecureconfig.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the organization with which the SDK message processing step is associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
-        public Microsoft.Xrm.Sdk.EntityReference OrganizationId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message processing step secure configuration.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepsecureconfigid")]
-        public System.Nullable<System.Guid> SdkMessageProcessingStepSecureConfigId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageprocessingstepsecureconfigid");
-            }
-            set
-            {
-                this.OnPropertyChanging("SdkMessageProcessingStepSecureConfigId");
-                this.SetAttributeValue("sdkmessageprocessingstepsecureconfigid", value);
-                if (value.HasValue)
-                {
-                    base.Id = value.Value;
-                }
-                else
-                {
-                    base.Id = System.Guid.Empty;
-                }
-                this.OnPropertyChanged("SdkMessageProcessingStepSecureConfigId");
-            }
-        }
-
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepsecureconfigid")]
-        public override System.Guid Id
-        {
-            get
-            {
-                return base.Id;
-            }
-            set
-            {
-                this.SdkMessageProcessingStepSecureConfigId = value;
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the SDK message processing step.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepsecureconfigidunique")]
-        public System.Nullable<System.Guid> SdkMessageProcessingStepSecureConfigIdUnique
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageprocessingstepsecureconfigidunique");
-            }
-        }
-
-        /// <summary>
-        /// Secure step-specific configuration for the plug-in type that is passed to the plug-in's constructor at run time.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("secureconfig")]
-        public string SecureConfig
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("secureconfig");
-            }
-            set
-            {
-                this.OnPropertyChanging("SecureConfig");
-                this.SetAttributeValue("secureconfig", value);
-                this.OnPropertyChanged("SecureConfig");
-            }
-        }
-
-        /// <summary>
-        /// 1:N sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep")]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStep> sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep");
-                this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep", null, value);
-                this.OnPropertyChanged("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep");
-            }
-        }
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum serviceendpoint_authtype
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        ACS = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        SASKey = 2,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        SASToken = 3,
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum serviceendpoint_connectionmode
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Normal = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Federated = 2,
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum serviceendpoint_contract
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        OneWay = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Queue = 2,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Rest = 3,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        TwoWay = 4,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Topic = 5,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Queue_Persistent = 6,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        EventHub = 7,
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum serviceendpoint_messageformat
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        BinaryXML = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Json = 2,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        TextXML = 3,
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum serviceendpoint_namespaceformat
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        NamespaceName = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        NamespaceAddress = 2,
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum serviceendpoint_userclaim
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        None = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        UserId = 2,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        UserInfo = 3,
-    }
-
-    /// <summary>
-    /// Service endpoint that can be contacted.
-    /// </summary>
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("serviceendpoint")]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class ServiceEndpoint : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
-    {
-
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        public ServiceEndpoint() :
-                base(EntityLogicalName)
-        {
-        }
-
-        public const string EntityLogicalName = "serviceendpoint";
-
-        public const int EntityTypeCode = 4618;
-
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
-        public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        private void OnPropertyChanging(string propertyName)
-        {
-            if ((this.PropertyChanging != null))
-            {
-                this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// Specifies mode of authentication with SB
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("authtype")]
-        public System.Nullable<SparkleXrm.Tasks.serviceendpoint_authtype> AuthType
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("authtype");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.serviceendpoint_authtype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.serviceendpoint_authtype), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("AuthType");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("authtype", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("authtype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("AuthType");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
-        public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
-            }
-        }
-
-        /// <summary>
-        /// Connection mode to contact the service endpoint.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("connectionmode")]
-        public System.Nullable<SparkleXrm.Tasks.serviceendpoint_connectionmode> ConnectionMode
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("connectionmode");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.serviceendpoint_connectionmode)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.serviceendpoint_connectionmode), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("ConnectionMode");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("connectionmode", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("connectionmode", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("ConnectionMode");
-            }
-        }
-
-        /// <summary>
-        /// Type of the endpoint contract.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("contract")]
-        public System.Nullable<SparkleXrm.Tasks.serviceendpoint_contract> Contract
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("contract");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.serviceendpoint_contract)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.serviceendpoint_contract), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("Contract");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("contract", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("contract", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("Contract");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who created the service endpoint.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the service endpoint was created.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
-        public System.Nullable<System.DateTime> CreatedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who created the service endpoint.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Description of the service endpoint.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
-        public string Description
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("description");
-            }
-            set
-            {
-                this.OnPropertyChanging("Description");
-                this.SetAttributeValue("description", value);
-                this.OnPropertyChanged("Description");
-            }
-        }
-
-        /// <summary>
-        /// Version in which the form is introduced.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
-        public string IntroducedVersion
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("introducedversion");
-            }
-            set
-            {
-                this.OnPropertyChanging("IntroducedVersion");
-                this.SetAttributeValue("introducedversion", value);
-                this.OnPropertyChanged("IntroducedVersion");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this component can be customized.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomizable")]
-        public Microsoft.Xrm.Sdk.BooleanManagedProperty IsCustomizable
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("iscustomizable");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsCustomizable");
-                this.SetAttributeValue("iscustomizable", value);
-                this.OnPropertyChanged("IsCustomizable");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this component is managed.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
-        public System.Nullable<bool> IsManaged
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("issaskeyset")]
-        public System.Nullable<bool> IsSASKeySet
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("issaskeyset");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("issastokenset")]
-        public System.Nullable<bool> IsSASTokenSet
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("issastokenset");
-            }
-        }
-
-        /// <summary>
-        /// Content type of the message
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("messageformat")]
-        public System.Nullable<SparkleXrm.Tasks.serviceendpoint_messageformat> MessageFormat
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("messageformat");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.serviceendpoint_messageformat)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.serviceendpoint_messageformat), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("MessageFormat");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("messageformat", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("messageformat", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("MessageFormat");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who last modified the service endpoint.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the service endpoint was last modified.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
-        public System.Nullable<System.DateTime> ModifiedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who modified the service endpoint.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Name of Service end point.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
-        public string Name
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("name");
-            }
-            set
-            {
-                this.OnPropertyChanging("Name");
-                this.SetAttributeValue("name", value);
-                this.OnPropertyChanged("Name");
-            }
-        }
-
-        /// <summary>
-        /// Full service endpoint address.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("namespaceaddress")]
-        public string NamespaceAddress
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("namespaceaddress");
-            }
-            set
-            {
-                this.OnPropertyChanging("NamespaceAddress");
-                this.SetAttributeValue("namespaceaddress", value);
-                this.OnPropertyChanged("NamespaceAddress");
-            }
-        }
-
-        /// <summary>
-        /// Format of Service Bus Namespace
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("namespaceformat")]
-        public System.Nullable<SparkleXrm.Tasks.serviceendpoint_namespaceformat> NamespaceFormat
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("namespaceformat");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.serviceendpoint_namespaceformat)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.serviceendpoint_namespaceformat), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("NamespaceFormat");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("namespaceformat", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("namespaceformat", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("NamespaceFormat");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the organization with which the service endpoint is associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
-        public Microsoft.Xrm.Sdk.EntityReference OrganizationId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
-        public System.Nullable<System.DateTime> OverwriteTime
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
-            }
-        }
-
-        /// <summary>
-        /// Path to the service endpoint.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("path")]
-        public string Path
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("path");
-            }
-            set
-            {
-                this.OnPropertyChanging("Path");
-                this.SetAttributeValue("path", value);
-                this.OnPropertyChanged("Path");
-            }
-        }
-
-        /// <summary>
-        /// Shared Access Key
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("saskey")]
-        public string SASKey
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("saskey");
-            }
-            set
-            {
-                this.OnPropertyChanging("SASKey");
-                this.SetAttributeValue("saskey", value);
-                this.OnPropertyChanged("SASKey");
-            }
-        }
-
-        /// <summary>
-        /// Shared Access Key Name
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("saskeyname")]
-        public string SASKeyName
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("saskeyname");
-            }
-            set
-            {
-                this.OnPropertyChanging("SASKeyName");
-                this.SetAttributeValue("saskeyname", value);
-                this.OnPropertyChanged("SASKeyName");
-            }
-        }
-
-        /// <summary>
-        /// Shared Access Token
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sastoken")]
-        public string SASToken
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("sastoken");
-            }
-            set
-            {
-                this.OnPropertyChanging("SASToken");
-                this.SetAttributeValue("sastoken", value);
-                this.OnPropertyChanged("SASToken");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the service endpoint.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("serviceendpointid")]
-        public System.Nullable<System.Guid> ServiceEndpointId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("serviceendpointid");
-            }
-            set
-            {
-                this.OnPropertyChanging("ServiceEndpointId");
-                this.SetAttributeValue("serviceendpointid", value);
-                if (value.HasValue)
-                {
-                    base.Id = value.Value;
-                }
-                else
-                {
-                    base.Id = System.Guid.Empty;
-                }
-                this.OnPropertyChanged("ServiceEndpointId");
-            }
-        }
-
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("serviceendpointid")]
-        public override System.Guid Id
-        {
-            get
-            {
-                return base.Id;
-            }
-            set
-            {
-                this.ServiceEndpointId = value;
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the service endpoint.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("serviceendpointidunique")]
-        public System.Nullable<System.Guid> ServiceEndpointIdUnique
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("serviceendpointidunique");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the associated solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
-        public System.Nullable<System.Guid> SolutionId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
-            }
-        }
-
-        /// <summary>
-        /// Namespace of the App Fabric solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionnamespace")]
-        public string SolutionNamespace
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("solutionnamespace");
-            }
-            set
-            {
-                this.OnPropertyChanging("SolutionNamespace");
-                this.SetAttributeValue("solutionnamespace", value);
-                this.OnPropertyChanged("SolutionNamespace");
-            }
-        }
-
-        /// <summary>
-        /// Additional user claim value type.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("userclaim")]
-        public System.Nullable<SparkleXrm.Tasks.serviceendpoint_userclaim> UserClaim
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("userclaim");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.serviceendpoint_userclaim)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.serviceendpoint_userclaim), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("UserClaim");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("userclaim", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("userclaim", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("UserClaim");
-            }
-        }
-
-        /// <summary>
-        /// 1:N serviceendpoint_sdkmessageprocessingstep
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("serviceendpoint_sdkmessageprocessingstep")]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStep> serviceendpoint_sdkmessageprocessingstep
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("serviceendpoint_sdkmessageprocessingstep", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("serviceendpoint_sdkmessageprocessingstep");
-                this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("serviceendpoint_sdkmessageprocessingstep", null, value);
-                this.OnPropertyChanged("serviceendpoint_sdkmessageprocessingstep");
-            }
-        }
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum solution_solutiontype
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        None = 0,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Snapshot = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Internal = 2,
-    }
-
-    /// <summary>
-    /// A solution which contains CRM customizations.
-    /// </summary>
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("solution")]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class Solution : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
-    {
-
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        public Solution() :
-                base(EntityLogicalName)
-        {
-        }
-
-        public const string EntityLogicalName = "solution";
-
-        public const int EntityTypeCode = 7100;
-
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
-        public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        private void OnPropertyChanging(string propertyName)
-        {
-            if ((this.PropertyChanging != null))
-            {
-                this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// A link to an optional configuration page for this solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("configurationpageid")]
-        public Microsoft.Xrm.Sdk.EntityReference ConfigurationPageId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("configurationpageid");
-            }
-            set
-            {
-                this.OnPropertyChanging("ConfigurationPageId");
-                this.SetAttributeValue("configurationpageid", value);
-                this.OnPropertyChanged("ConfigurationPageId");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who created the solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the solution was created.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
-        public System.Nullable<System.DateTime> CreatedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who created the solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Description of the solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
-        public string Description
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("description");
-            }
-            set
-            {
-                this.OnPropertyChanging("Description");
-                this.SetAttributeValue("description", value);
-                this.OnPropertyChanged("Description");
-            }
-        }
-
-        /// <summary>
-        /// User display name for the solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("friendlyname")]
-        public string FriendlyName
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("friendlyname");
-            }
-            set
-            {
-                this.OnPropertyChanging("FriendlyName");
-                this.SetAttributeValue("friendlyname", value);
-                this.OnPropertyChanged("FriendlyName");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the solution was installed/upgraded.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("installedon")]
-        public System.Nullable<System.DateTime> InstalledOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("installedon");
-            }
-        }
-
-        /// <summary>
-        /// Indicates whether the solution is managed or unmanaged.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
-        public System.Nullable<bool> IsManaged
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
-            }
-        }
-
-        /// <summary>
-        /// Indicates whether the solution is visible outside of the platform.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isvisible")]
-        public System.Nullable<bool> IsVisible
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("isvisible");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who last modified the solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the solution was last modified.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
-        public System.Nullable<System.DateTime> ModifiedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who modified the solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the organization associated with the solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
-        public Microsoft.Xrm.Sdk.EntityReference OrganizationId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the parent solution. Should only be non-null if this solution is a patch.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("parentsolutionid")]
-        public Microsoft.Xrm.Sdk.EntityReference ParentSolutionId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("parentsolutionid");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pinpointassetid")]
-        public string PinpointAssetId
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("pinpointassetid");
-            }
-        }
-
-        /// <summary>
-        /// Identifier of the publisher of this solution in Microsoft Pinpoint.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pinpointpublisherid")]
-        public System.Nullable<long> PinpointPublisherId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<long>>("pinpointpublisherid");
-            }
-        }
-
-        /// <summary>
-        /// Default locale of the solution in Microsoft Pinpoint.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pinpointsolutiondefaultlocale")]
-        public string PinpointSolutionDefaultLocale
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("pinpointsolutiondefaultlocale");
-            }
-        }
-
-        /// <summary>
-        /// Identifier of the solution in Microsoft Pinpoint.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pinpointsolutionid")]
-        public System.Nullable<long> PinpointSolutionId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<long>>("pinpointsolutionid");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the publisher.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("publisherid")]
-        public Microsoft.Xrm.Sdk.EntityReference PublisherId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("publisherid");
-            }
-            set
-            {
-                this.OnPropertyChanging("PublisherId");
-                this.SetAttributeValue("publisherid", value);
-                this.OnPropertyChanged("PublisherId");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
-        public System.Nullable<System.Guid> SolutionId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
-            }
-            set
-            {
-                this.OnPropertyChanging("SolutionId");
-                this.SetAttributeValue("solutionid", value);
-                if (value.HasValue)
-                {
-                    base.Id = value.Value;
-                }
-                else
-                {
-                    base.Id = System.Guid.Empty;
-                }
-                this.OnPropertyChanged("SolutionId");
-            }
-        }
-
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
-        public override System.Guid Id
-        {
-            get
-            {
-                return base.Id;
-            }
-            set
-            {
-                this.SolutionId = value;
-            }
-        }
-
-        /// <summary>
-        /// Solution package source organization version
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionpackageversion")]
-        public string SolutionPackageVersion
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("solutionpackageversion");
-            }
-            set
-            {
-                this.OnPropertyChanging("SolutionPackageVersion");
-                this.SetAttributeValue("solutionpackageversion", value);
-                this.OnPropertyChanged("SolutionPackageVersion");
-            }
-        }
-
-        /// <summary>
-        /// Solution Type
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutiontype")]
-        public System.Nullable<SparkleXrm.Tasks.solution_solutiontype> SolutionType
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("solutiontype");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.solution_solutiontype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.solution_solutiontype), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("SolutionType");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("solutiontype", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("solutiontype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("SolutionType");
-            }
-        }
-
-        /// <summary>
-        /// The unique name of this solution
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("uniquename")]
-        public string UniqueName
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("uniquename");
-            }
-            set
-            {
-                this.OnPropertyChanging("UniqueName");
-                this.SetAttributeValue("uniquename", value);
-                this.OnPropertyChanged("UniqueName");
-            }
-        }
-
-        /// <summary>
-        /// Solution version, used to identify a solution for upgrades and hotfixes.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("version")]
-        public string Version
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("version");
-            }
-            set
-            {
-                this.OnPropertyChanging("Version");
-                this.SetAttributeValue("version", value);
-                this.OnPropertyChanged("Version");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
-        public System.Nullable<long> VersionNumber
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
-            }
-        }
-
-        /// <summary>
-        /// 1:N solution_parent_solution
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solution_parent_solution", Microsoft.Xrm.Sdk.EntityRole.Referenced)]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.Solution> Referencedsolution_parent_solution
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.Solution>("solution_parent_solution", Microsoft.Xrm.Sdk.EntityRole.Referenced);
-            }
-            set
-            {
-                this.OnPropertyChanging("Referencedsolution_parent_solution");
-                this.SetRelatedEntities<SparkleXrm.Tasks.Solution>("solution_parent_solution", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
-                this.OnPropertyChanged("Referencedsolution_parent_solution");
-            }
-        }
-
-        /// <summary>
-        /// 1:N solution_solutioncomponent
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solution_solutioncomponent")]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SolutionComponent> solution_solutioncomponent
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.SolutionComponent>("solution_solutioncomponent", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("solution_solutioncomponent");
-                this.SetRelatedEntities<SparkleXrm.Tasks.SolutionComponent>("solution_solutioncomponent", null, value);
-                this.OnPropertyChanged("solution_solutioncomponent");
-            }
-        }
-
-        /// <summary>
-        /// N:1 solution_configuration_webresource
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("configurationpageid")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solution_configuration_webresource")]
-        public SparkleXrm.Tasks.WebResource solution_configuration_webresource
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.WebResource>("solution_configuration_webresource", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("solution_configuration_webresource");
-                this.SetRelatedEntity<SparkleXrm.Tasks.WebResource>("solution_configuration_webresource", null, value);
-                this.OnPropertyChanged("solution_configuration_webresource");
-            }
-        }
-
-        /// <summary>
-        /// N:1 solution_parent_solution
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("parentsolutionid")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solution_parent_solution", Microsoft.Xrm.Sdk.EntityRole.Referencing)]
-        public SparkleXrm.Tasks.Solution Referencingsolution_parent_solution
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.Solution>("solution_parent_solution", Microsoft.Xrm.Sdk.EntityRole.Referencing);
-            }
-        }
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum solutioncomponent_rootcomponentbehavior
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        IncludeSubcomponents = 0,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Donotincludesubcomponents = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        IncludeAsShellOnly = 2,
-    }
-
-    /// <summary>
-    /// A component of a CRM solution.
-    /// </summary>
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("solutioncomponent")]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class SolutionComponent : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
-    {
-
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        public SolutionComponent() :
-                base(EntityLogicalName)
-        {
-        }
-
-        public const string EntityLogicalName = "solutioncomponent";
-
-        public const int EntityTypeCode = 7103;
-
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
-        public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        private void OnPropertyChanging(string propertyName)
-        {
-            if ((this.PropertyChanging != null))
-            {
-                this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// The object type code of the component.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componenttype")]
-        public Microsoft.Xrm.Sdk.OptionSetValue ComponentType
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componenttype");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who created the solution
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the solution was created.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
-        public System.Nullable<System.DateTime> CreatedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who created the solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Indicates whether this component is metadata or data.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismetadata")]
-        public System.Nullable<bool> IsMetadata
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("ismetadata");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who last modified the solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the solution was last modified.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
-        public System.Nullable<System.DateTime> ModifiedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who modified the solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the object with which the component is associated.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("objectid")]
-        public System.Nullable<System.Guid> ObjectId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("objectid");
-            }
-        }
-
-        /// <summary>
-        /// Indicates the include behavior of the root component.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("rootcomponentbehavior")]
-        public System.Nullable<SparkleXrm.Tasks.solutioncomponent_rootcomponentbehavior> RootComponentBehavior
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("rootcomponentbehavior");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.solutioncomponent_rootcomponentbehavior)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.solutioncomponent_rootcomponentbehavior), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
-
-        /// <summary>
-        /// The parent ID of the subcomponent, which will be a root
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("rootsolutioncomponentid")]
-        public System.Nullable<System.Guid> RootSolutionComponentId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("rootsolutioncomponentid");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the solution component.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutioncomponentid")]
-        public System.Nullable<System.Guid> SolutionComponentId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("solutioncomponentid");
-            }
-        }
-
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutioncomponentid")]
-        public override System.Guid Id
-        {
-            get
-            {
-                return base.Id;
-            }
-            set
-            {
-                base.Id = value;
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
-        public Microsoft.Xrm.Sdk.EntityReference SolutionId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("solutionid");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
-        public System.Nullable<long> VersionNumber
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
-            }
-        }
-
-        /// <summary>
-        /// 1:N solutioncomponent_parent_solutioncomponent
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solutioncomponent_parent_solutioncomponent", Microsoft.Xrm.Sdk.EntityRole.Referenced)]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SolutionComponent> Referencedsolutioncomponent_parent_solutioncomponent
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.SolutionComponent>("solutioncomponent_parent_solutioncomponent", Microsoft.Xrm.Sdk.EntityRole.Referenced);
-            }
-            set
-            {
-                this.OnPropertyChanging("Referencedsolutioncomponent_parent_solutioncomponent");
-                this.SetRelatedEntities<SparkleXrm.Tasks.SolutionComponent>("solutioncomponent_parent_solutioncomponent", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
-                this.OnPropertyChanged("Referencedsolutioncomponent_parent_solutioncomponent");
-            }
-        }
-
-        /// <summary>
-        /// N:1 solution_solutioncomponent
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solution_solutioncomponent")]
-        public SparkleXrm.Tasks.Solution solution_solutioncomponent
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.Solution>("solution_solutioncomponent", null);
-            }
-        }
-
-        /// <summary>
-        /// N:1 solutioncomponent_parent_solutioncomponent
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("rootsolutioncomponentid")]
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solutioncomponent_parent_solutioncomponent", Microsoft.Xrm.Sdk.EntityRole.Referencing)]
-        public SparkleXrm.Tasks.SolutionComponent Referencingsolutioncomponent_parent_solutioncomponent
-        {
-            get
-            {
-                return this.GetRelatedEntity<SparkleXrm.Tasks.SolutionComponent>("solutioncomponent_parent_solutioncomponent", Microsoft.Xrm.Sdk.EntityRole.Referencing);
-            }
-        }
-    }
-
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public enum webresource_webresourcetype
-    {
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Webpage_HTML = 1,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        StyleSheet_CSS = 2,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Script_JScript = 3,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Data_XML = 4,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        PNGformat = 5,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        JPGformat = 6,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        GIFformat = 7,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Silverlight_XAP = 8,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        StyleSheet_XSL = 9,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        ICOformat = 10,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Vectorformat_SVG = 11,
-
-        [System.Runtime.Serialization.EnumMemberAttribute()]
-        Resourceformat_RESX = 12,
-    }
-
-    /// <summary>
-    /// Data equivalent to files used in Web development. Web resources provide client-side components that are used to provide custom user interface elements.
-    /// </summary>
-    [System.Runtime.Serialization.DataContractAttribute()]
-    [Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("webresource")]
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class WebResource : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
-    {
-
-        /// <summary>
-        /// Default Constructor.
-        /// </summary>
-        public WebResource() :
-                base(EntityLogicalName)
-        {
-        }
-
-        public const string EntityLogicalName = "webresource";
-
-        public const int EntityTypeCode = 9333;
-
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-
-        public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
-
-        private void OnPropertyChanged(string propertyName)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-            }
-        }
-
-        private void OnPropertyChanging(string propertyName)
-        {
-            if ((this.PropertyChanging != null))
-            {
-                this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this component can be deleted.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("canbedeleted")]
-        public Microsoft.Xrm.Sdk.BooleanManagedProperty CanBeDeleted
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("canbedeleted");
-            }
-            set
-            {
-                this.OnPropertyChanging("CanBeDeleted");
-                this.SetAttributeValue("canbedeleted", value);
-                this.OnPropertyChanged("CanBeDeleted");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
-        public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
-            }
-        }
-
-        /// <summary>
-        /// Bytes of the web resource, in Base64 format.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("content")]
-        public string Content
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("content");
-            }
-            set
-            {
-                this.OnPropertyChanging("Content");
-                this.SetAttributeValue("content", value);
-                this.OnPropertyChanged("Content");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who created the web resource.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the web resource was created.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
-        public System.Nullable<System.DateTime> CreatedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who created the web resource.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dependencyxml")]
-        public string DependencyXml
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("dependencyxml");
-            }
-            set
-            {
-                this.OnPropertyChanging("DependencyXml");
-                this.SetAttributeValue("dependencyxml", value);
-                this.OnPropertyChanged("DependencyXml");
-            }
-        }
-
-        /// <summary>
-        /// Description of the web resource.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
-        public string Description
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("description");
-            }
-            set
-            {
-                this.OnPropertyChanging("Description");
-                this.SetAttributeValue("description", value);
-                this.OnPropertyChanged("Description");
-            }
-        }
-
-        /// <summary>
-        /// Display name of the web resource.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("displayname")]
-        public string DisplayName
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("displayname");
-            }
-            set
-            {
-                this.OnPropertyChanging("DisplayName");
-                this.SetAttributeValue("displayname", value);
-                this.OnPropertyChanged("DisplayName");
-            }
-        }
-
-        /// <summary>
-        /// Version in which the form is introduced.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
-        public string IntroducedVersion
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("introducedversion");
-            }
-            set
-            {
-                this.OnPropertyChanging("IntroducedVersion");
-                this.SetAttributeValue("introducedversion", value);
-                this.OnPropertyChanged("IntroducedVersion");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this web resource is available for mobile client in offline mode.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isavailableformobileoffline")]
-        public System.Nullable<bool> IsAvailableForMobileOffline
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("isavailableformobileoffline");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsAvailableForMobileOffline");
-                this.SetAttributeValue("isavailableformobileoffline", value);
-                this.OnPropertyChanged("IsAvailableForMobileOffline");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this component can be customized.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomizable")]
-        public Microsoft.Xrm.Sdk.BooleanManagedProperty IsCustomizable
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("iscustomizable");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsCustomizable");
-                this.SetAttributeValue("iscustomizable", value);
-                this.OnPropertyChanged("IsCustomizable");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this web resource is enabled for mobile client.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isenabledformobileclient")]
-        public System.Nullable<bool> IsEnabledForMobileClient
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("isenabledformobileclient");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsEnabledForMobileClient");
-                this.SetAttributeValue("isenabledformobileclient", value);
-                this.OnPropertyChanged("IsEnabledForMobileClient");
-            }
-        }
-
-        /// <summary>
-        /// Information that specifies whether this component should be hidden.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ishidden")]
-        public Microsoft.Xrm.Sdk.BooleanManagedProperty IsHidden
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("ishidden");
-            }
-            set
-            {
-                this.OnPropertyChanging("IsHidden");
-                this.SetAttributeValue("ishidden", value);
-                this.OnPropertyChanged("IsHidden");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
-        public System.Nullable<bool> IsManaged
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
-            }
-        }
-
-        /// <summary>
-        /// Language of the web resource.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("languagecode")]
-        public System.Nullable<int> LanguageCode
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<int>>("languagecode");
-            }
-            set
-            {
-                this.OnPropertyChanging("LanguageCode");
-                this.SetAttributeValue("languagecode", value);
-                this.OnPropertyChanged("LanguageCode");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the user who last modified the web resource.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
-            }
-        }
-
-        /// <summary>
-        /// Date and time when the web resource was last modified.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
-        public System.Nullable<System.DateTime> ModifiedOn
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the delegate user who modified the web resource.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
-        public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
-            }
-        }
-
-        /// <summary>
-        /// Name of the web resource.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
-        public string Name
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("name");
-            }
-            set
-            {
-                this.OnPropertyChanging("Name");
-                this.SetAttributeValue("name", value);
-                this.OnPropertyChanged("Name");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the organization associated with the web resource.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
-        public Microsoft.Xrm.Sdk.EntityReference OrganizationId
-        {
-            get
-            {
-                return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
-        public System.Nullable<System.DateTime> OverwriteTime
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
-            }
-        }
-
-        /// <summary>
-        /// Silverlight runtime version number required by a silverlight web resource.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("silverlightversion")]
-        public string SilverlightVersion
-        {
-            get
-            {
-                return this.GetAttributeValue<string>("silverlightversion");
-            }
-            set
-            {
-                this.OnPropertyChanging("SilverlightVersion");
-                this.SetAttributeValue("silverlightversion", value);
-                this.OnPropertyChanged("SilverlightVersion");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the associated solution.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
-        public System.Nullable<System.Guid> SolutionId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
-            }
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
-        public System.Nullable<long> VersionNumber
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
-            }
-        }
-
-        /// <summary>
-        /// Unique identifier of the web resource.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("webresourceid")]
-        public System.Nullable<System.Guid> WebResourceId
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("webresourceid");
-            }
-            set
-            {
-                this.OnPropertyChanging("WebResourceId");
-                this.SetAttributeValue("webresourceid", value);
-                if (value.HasValue)
-                {
-                    base.Id = value.Value;
-                }
-                else
-                {
-                    base.Id = System.Guid.Empty;
-                }
-                this.OnPropertyChanged("WebResourceId");
-            }
-        }
-
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("webresourceid")]
-        public override System.Guid Id
-        {
-            get
-            {
-                return base.Id;
-            }
-            set
-            {
-                this.WebResourceId = value;
-            }
-        }
-
-        /// <summary>
-        /// For internal use only.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("webresourceidunique")]
-        public System.Nullable<System.Guid> WebResourceIdUnique
-        {
-            get
-            {
-                return this.GetAttributeValue<System.Nullable<System.Guid>>("webresourceidunique");
-            }
-        }
-
-        /// <summary>
-        /// Drop-down list for selecting the type of the web resource.
-        /// </summary>
-        [Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("webresourcetype")]
-        public System.Nullable<SparkleXrm.Tasks.webresource_webresourcetype> WebResourceType
-        {
-            get
-            {
-                Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("webresourcetype");
-                if ((optionSet != null))
-                {
-                    return ((SparkleXrm.Tasks.webresource_webresourcetype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.webresource_webresourcetype), optionSet.Value)));
-                }
-                else
-                {
-                    return null;
-                }
-            }
-            set
-            {
-                this.OnPropertyChanging("WebResourceType");
-                if ((value == null))
-                {
-                    this.SetAttributeValue("webresourcetype", null);
-                }
-                else
-                {
-                    this.SetAttributeValue("webresourcetype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
-                }
-                this.OnPropertyChanged("WebResourceType");
-            }
-        }
-
-        /// <summary>
-        /// 1:N solution_configuration_webresource
-        /// </summary>
-        [Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solution_configuration_webresource")]
-        public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.Solution> solution_configuration_webresource
-        {
-            get
-            {
-                return this.GetRelatedEntities<SparkleXrm.Tasks.Solution>("solution_configuration_webresource", null);
-            }
-            set
-            {
-                this.OnPropertyChanging("solution_configuration_webresource");
-                this.SetRelatedEntities<SparkleXrm.Tasks.Solution>("solution_configuration_webresource", null, value);
-                this.OnPropertyChanged("solution_configuration_webresource");
-            }
-        }
-    }
-
-    /// <summary>
-    /// Represents a source of entities bound to a CRM service. It tracks and manages changes made to the retrieved entities.
-    /// </summary>
-    [System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "8.2.1.8676")]
-    public partial class OrganizationServiceContext1 : Microsoft.Xrm.Sdk.Client.OrganizationServiceContext
-    {
-
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        public OrganizationServiceContext1(Microsoft.Xrm.Sdk.IOrganizationService service) :
-                base(service)
-        {
-        }
-
-        /// <summary>
-        /// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.PluginAssembly"/> entities.
-        /// </summary>
-        public System.Linq.IQueryable<SparkleXrm.Tasks.PluginAssembly> PluginAssemblySet
-        {
-            get
-            {
-                return this.CreateQuery<SparkleXrm.Tasks.PluginAssembly>();
-            }
-        }
-
-        /// <summary>
-        /// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.PluginType"/> entities.
-        /// </summary>
-        public System.Linq.IQueryable<SparkleXrm.Tasks.PluginType> PluginTypeSet
-        {
-            get
-            {
-                return this.CreateQuery<SparkleXrm.Tasks.PluginType>();
-            }
-        }
-
-        /// <summary>
-        /// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SdkMessage"/> entities.
-        /// </summary>
-        public System.Linq.IQueryable<SparkleXrm.Tasks.SdkMessage> SdkMessageSet
-        {
-            get
-            {
-                return this.CreateQuery<SparkleXrm.Tasks.SdkMessage>();
-            }
-        }
-
-        /// <summary>
-        /// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SdkMessageFilter"/> entities.
-        /// </summary>
-        public System.Linq.IQueryable<SparkleXrm.Tasks.SdkMessageFilter> SdkMessageFilterSet
-        {
-            get
-            {
-                return this.CreateQuery<SparkleXrm.Tasks.SdkMessageFilter>();
-            }
-        }
-
-        /// <summary>
-        /// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SdkMessagePair"/> entities.
-        /// </summary>
-        public System.Linq.IQueryable<SparkleXrm.Tasks.SdkMessagePair> SdkMessagePairSet
-        {
-            get
-            {
-                return this.CreateQuery<SparkleXrm.Tasks.SdkMessagePair>();
-            }
-        }
-
-        /// <summary>
-        /// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SdkMessageProcessingStep"/> entities.
-        /// </summary>
-        public System.Linq.IQueryable<SparkleXrm.Tasks.SdkMessageProcessingStep> SdkMessageProcessingStepSet
-        {
-            get
-            {
-                return this.CreateQuery<SparkleXrm.Tasks.SdkMessageProcessingStep>();
-            }
-        }
-
-        /// <summary>
-        /// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SdkMessageProcessingStepImage"/> entities.
-        /// </summary>
-        public System.Linq.IQueryable<SparkleXrm.Tasks.SdkMessageProcessingStepImage> SdkMessageProcessingStepImageSet
-        {
-            get
-            {
-                return this.CreateQuery<SparkleXrm.Tasks.SdkMessageProcessingStepImage>();
-            }
-        }
-
-        /// <summary>
-        /// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SdkMessageProcessingStepSecureConfig"/> entities.
-        /// </summary>
-        public System.Linq.IQueryable<SparkleXrm.Tasks.SdkMessageProcessingStepSecureConfig> SdkMessageProcessingStepSecureConfigSet
-        {
-            get
-            {
-                return this.CreateQuery<SparkleXrm.Tasks.SdkMessageProcessingStepSecureConfig>();
-            }
-        }
-
-        /// <summary>
-        /// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.ServiceEndpoint"/> entities.
-        /// </summary>
-        public System.Linq.IQueryable<SparkleXrm.Tasks.ServiceEndpoint> ServiceEndpointSet
-        {
-            get
-            {
-                return this.CreateQuery<SparkleXrm.Tasks.ServiceEndpoint>();
-            }
-        }
-
-        /// <summary>
-        /// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.Solution"/> entities.
-        /// </summary>
-        public System.Linq.IQueryable<SparkleXrm.Tasks.Solution> SolutionSet
-        {
-            get
-            {
-                return this.CreateQuery<SparkleXrm.Tasks.Solution>();
-            }
-        }
-
-        /// <summary>
-        /// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SolutionComponent"/> entities.
-        /// </summary>
-        public System.Linq.IQueryable<SparkleXrm.Tasks.SolutionComponent> SolutionComponentSet
-        {
-            get
-            {
-                return this.CreateQuery<SparkleXrm.Tasks.SolutionComponent>();
-            }
-        }
-
-        /// <summary>
-        /// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.WebResource"/> entities.
-        /// </summary>
-        public System.Linq.IQueryable<SparkleXrm.Tasks.WebResource> WebResourceSet
-        {
-            get
-            {
-                return this.CreateQuery<SparkleXrm.Tasks.WebResource>();
-            }
-        }
-    }
+	
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum customapi_allowedcustomprocessingsteptype
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		None = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		AsyncOnly = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		SyncandAsync = 2,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum customapi_bindingtype
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Global = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Entity = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		EntityCollection = 2,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum CustomAPIState
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Active = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Inactive = 1,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum customapi_statuscode
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Active = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Inactive = 2,
+	}
+	
+	/// <summary>
+	/// Entity that defines a custom API
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("customapi")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class CustomAPI : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public CustomAPI() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "customapi";
+		
+		public const int EntityTypeCode = 10052;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// The type of custom processing step allowed
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("allowedcustomprocessingsteptype")]
+		public System.Nullable<SparkleXrm.Tasks.customapi_allowedcustomprocessingsteptype> AllowedCustomProcessingStepType
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("allowedcustomprocessingsteptype");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.customapi_allowedcustomprocessingsteptype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.customapi_allowedcustomprocessingsteptype), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("AllowedCustomProcessingStepType");
+				if ((value == null))
+				{
+					this.SetAttributeValue("allowedcustomprocessingsteptype", null);
+				}
+				else
+				{
+					this.SetAttributeValue("allowedcustomprocessingsteptype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("AllowedCustomProcessingStepType");
+			}
+		}
+		
+		/// <summary>
+		/// The binding type of the custom API
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("bindingtype")]
+		public System.Nullable<SparkleXrm.Tasks.customapi_bindingtype> BindingType
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("bindingtype");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.customapi_bindingtype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.customapi_bindingtype), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("BindingType");
+				if ((value == null))
+				{
+					this.SetAttributeValue("bindingtype", null);
+				}
+				else
+				{
+					this.SetAttributeValue("bindingtype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("BindingType");
+			}
+		}
+		
+		/// <summary>
+		/// The logical name of the entity bound to the custom API
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("boundentitylogicalname")]
+		public string BoundEntityLogicalName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("boundentitylogicalname");
+			}
+			set
+			{
+				this.OnPropertyChanging("BoundEntityLogicalName");
+				this.SetAttributeValue("boundentitylogicalname", value);
+				this.OnPropertyChanged("BoundEntityLogicalName");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentidunique")]
+		public System.Nullable<System.Guid> ComponentIdUnique
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("componentidunique");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
+		public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the record.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the record was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the record.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier for custom API instances
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customapiid")]
+		public System.Nullable<System.Guid> CustomAPIId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("customapiid");
+			}
+			set
+			{
+				this.OnPropertyChanging("CustomAPIId");
+				this.SetAttributeValue("customapiid", value);
+				if (value.HasValue)
+				{
+					base.Id = value.Value;
+				}
+				else
+				{
+					base.Id = System.Guid.Empty;
+				}
+				this.OnPropertyChanged("CustomAPIId");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customapiid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				this.CustomAPIId = value;
+			}
+		}
+		
+		/// <summary>
+		/// Localized description for custom API instances
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
+		public string Description
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("description");
+			}
+			set
+			{
+				this.OnPropertyChanging("Description");
+				this.SetAttributeValue("description", value);
+				this.OnPropertyChanged("Description");
+			}
+		}
+		
+		/// <summary>
+		/// Localized display name for custom API instances
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("displayname")]
+		public string DisplayName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("displayname");
+			}
+			set
+			{
+				this.OnPropertyChanging("DisplayName");
+				this.SetAttributeValue("displayname", value);
+				this.OnPropertyChanged("DisplayName");
+			}
+		}
+		
+		/// <summary>
+		/// Name of the privilege that allows execution of the custom API
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("executeprivilegename")]
+		public string ExecutePrivilegeName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("executeprivilegename");
+			}
+			set
+			{
+				this.OnPropertyChanging("ExecutePrivilegeName");
+				this.SetAttributeValue("executeprivilegename", value);
+				this.OnPropertyChanged("ExecutePrivilegeName");
+			}
+		}
+		
+		/// <summary>
+		/// Sequence number of the import that created this record.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("importsequencenumber")]
+		public System.Nullable<int> ImportSequenceNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("importsequencenumber");
+			}
+			set
+			{
+				this.OnPropertyChanging("ImportSequenceNumber");
+				this.SetAttributeValue("importsequencenumber", value);
+				this.OnPropertyChanged("ImportSequenceNumber");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomizable")]
+		public Microsoft.Xrm.Sdk.BooleanManagedProperty IsCustomizable
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("iscustomizable");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsCustomizable");
+				this.SetAttributeValue("iscustomizable", value);
+				this.OnPropertyChanged("IsCustomizable");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates if the custom API is a function (GET is supported) or not (POST is supported)
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isfunction")]
+		public System.Nullable<bool> IsFunction
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isfunction");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsFunction");
+				this.SetAttributeValue("isfunction", value);
+				this.OnPropertyChanged("IsFunction");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates whether the solution component is part of a managed solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
+		public System.Nullable<bool> IsManaged
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates if the custom API is private (hidden from metadata and documentation)
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isprivate")]
+		public System.Nullable<bool> IsPrivate
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isprivate");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsPrivate");
+				this.SetAttributeValue("isprivate", value);
+				this.OnPropertyChanged("IsPrivate");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who modified the record.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the record was modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who modified the record.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// The primary name of the custom API
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
+		public string Name
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("name");
+			}
+			set
+			{
+				this.OnPropertyChanging("Name");
+				this.SetAttributeValue("name", value);
+				this.OnPropertyChanged("Name");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time that the record was migrated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overriddencreatedon")]
+		public System.Nullable<System.DateTime> OverriddenCreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("overriddencreatedon");
+			}
+			set
+			{
+				this.OnPropertyChanging("OverriddenCreatedOn");
+				this.SetAttributeValue("overriddencreatedon", value);
+				this.OnPropertyChanged("OverriddenCreatedOn");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
+		public System.Nullable<System.DateTime> OverwriteTime
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
+			}
+		}
+		
+		/// <summary>
+		/// Owner Id
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ownerid")]
+		public Microsoft.Xrm.Sdk.EntityReference OwnerId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("ownerid");
+			}
+			set
+			{
+				this.OnPropertyChanging("OwnerId");
+				this.SetAttributeValue("ownerid", value);
+				this.OnPropertyChanged("OwnerId");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier for the business unit that owns the record
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("owningbusinessunit")]
+		public Microsoft.Xrm.Sdk.EntityReference OwningBusinessUnit
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("owningbusinessunit");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier for the team that owns the record.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("owningteam")]
+		public Microsoft.Xrm.Sdk.EntityReference OwningTeam
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("owningteam");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier for the user that owns the record.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("owninguser")]
+		public Microsoft.Xrm.Sdk.EntityReference OwningUser
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("owninguser");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("plugintypeid")]
+		public Microsoft.Xrm.Sdk.EntityReference PluginTypeId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("plugintypeid");
+			}
+			set
+			{
+				this.OnPropertyChanging("PluginTypeId");
+				this.SetAttributeValue("plugintypeid", value);
+				this.OnPropertyChanged("PluginTypeId");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
+		public Microsoft.Xrm.Sdk.EntityReference SdkMessageId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessageid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessageId");
+				this.SetAttributeValue("sdkmessageid", value);
+				this.OnPropertyChanged("SdkMessageId");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the associated solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public System.Nullable<System.Guid> SolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
+			}
+		}
+		
+		/// <summary>
+		/// Status of the Custom API
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("statecode")]
+		public System.Nullable<SparkleXrm.Tasks.CustomAPIState> statecode
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("statecode");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.CustomAPIState)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.CustomAPIState), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("statecode");
+				if ((value == null))
+				{
+					this.SetAttributeValue("statecode", null);
+				}
+				else
+				{
+					this.SetAttributeValue("statecode", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("statecode");
+			}
+		}
+		
+		/// <summary>
+		/// Reason for the status of the Custom API
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("statuscode")]
+		public System.Nullable<SparkleXrm.Tasks.customapi_statuscode> statuscode
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("statuscode");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.customapi_statuscode)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.customapi_statuscode), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("statuscode");
+				if ((value == null))
+				{
+					this.SetAttributeValue("statuscode", null);
+				}
+				else
+				{
+					this.SetAttributeValue("statuscode", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("statuscode");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("timezoneruleversionnumber")]
+		public System.Nullable<int> TimeZoneRuleVersionNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("timezoneruleversionnumber");
+			}
+			set
+			{
+				this.OnPropertyChanging("TimeZoneRuleVersionNumber");
+				this.SetAttributeValue("timezoneruleversionnumber", value);
+				this.OnPropertyChanged("TimeZoneRuleVersionNumber");
+			}
+		}
+		
+		/// <summary>
+		/// Unique name for the custom API
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("uniquename")]
+		public string UniqueName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("uniquename");
+			}
+			set
+			{
+				this.OnPropertyChanging("UniqueName");
+				this.SetAttributeValue("uniquename", value);
+				this.OnPropertyChanged("UniqueName");
+			}
+		}
+		
+		/// <summary>
+		/// Time zone code that was in use when the record was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("utcconversiontimezonecode")]
+		public System.Nullable<int> UTCConversionTimeZoneCode
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("utcconversiontimezonecode");
+			}
+			set
+			{
+				this.OnPropertyChanging("UTCConversionTimeZoneCode");
+				this.SetAttributeValue("utcconversiontimezonecode", value);
+				this.OnPropertyChanged("UTCConversionTimeZoneCode");
+			}
+		}
+		
+		/// <summary>
+		/// Version Number
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
+		public System.Nullable<long> VersionNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 plugintype_customapi
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("plugintypeid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("plugintype_customapi")]
+		public SparkleXrm.Tasks.PluginType plugintype_customapi
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.PluginType>("plugintype_customapi", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("plugintype_customapi");
+				this.SetRelatedEntity<SparkleXrm.Tasks.PluginType>("plugintype_customapi", null, value);
+				this.OnPropertyChanged("plugintype_customapi");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 sdkmessage_customapi
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessage_customapi")]
+		public SparkleXrm.Tasks.SdkMessage sdkmessage_customapi
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessage>("sdkmessage_customapi", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("sdkmessage_customapi");
+				this.SetRelatedEntity<SparkleXrm.Tasks.SdkMessage>("sdkmessage_customapi", null, value);
+				this.OnPropertyChanged("sdkmessage_customapi");
+			}
+		}
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum pluginassembly_authtype
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		BasicAuth = 0,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum pluginassembly_isolationmode
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		None = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Sandbox = 2,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		External = 3,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum pluginassembly_sourcetype
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Database = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Disk = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Normal = 2,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		AzureWebApp = 3,
+	}
+	
+	/// <summary>
+	/// Assembly that contains one or more plug-in types.
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("pluginassembly")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class PluginAssembly : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public PluginAssembly() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "pluginassembly";
+		
+		public const int EntityTypeCode = 4605;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// Specifies mode of authentication with web sources like WebApp
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("authtype")]
+		public System.Nullable<SparkleXrm.Tasks.pluginassembly_authtype> AuthType
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("authtype");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.pluginassembly_authtype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.pluginassembly_authtype), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("AuthType");
+				if ((value == null))
+				{
+					this.SetAttributeValue("authtype", null);
+				}
+				else
+				{
+					this.SetAttributeValue("authtype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("AuthType");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
+		public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
+			}
+		}
+		
+		/// <summary>
+		/// Bytes of the assembly, in Base64 format.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("content")]
+		public string Content
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("content");
+			}
+			set
+			{
+				this.OnPropertyChanging("Content");
+				this.SetAttributeValue("content", value);
+				this.OnPropertyChanged("Content");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the plug-in assembly.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the plug-in assembly was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the pluginassembly.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Culture code for the plug-in assembly.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("culture")]
+		public string Culture
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("culture");
+			}
+			set
+			{
+				this.OnPropertyChanging("Culture");
+				this.SetAttributeValue("culture", value);
+				this.OnPropertyChanged("Culture");
+			}
+		}
+		
+		/// <summary>
+		/// Customization Level.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
+		public System.Nullable<int> CustomizationLevel
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
+			}
+		}
+		
+		/// <summary>
+		/// Description of the plug-in assembly.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
+		public string Description
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("description");
+			}
+			set
+			{
+				this.OnPropertyChanging("Description");
+				this.SetAttributeValue("description", value);
+				this.OnPropertyChanged("Description");
+			}
+		}
+		
+		/// <summary>
+		/// Version in which the form is introduced.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
+		public string IntroducedVersion
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("introducedversion");
+			}
+			set
+			{
+				this.OnPropertyChanging("IntroducedVersion");
+				this.SetAttributeValue("introducedversion", value);
+				this.OnPropertyChanged("IntroducedVersion");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component can be customized.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomizable")]
+		public Microsoft.Xrm.Sdk.BooleanManagedProperty IsCustomizable
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("iscustomizable");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsCustomizable");
+				this.SetAttributeValue("iscustomizable", value);
+				this.OnPropertyChanged("IsCustomizable");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component should be hidden.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ishidden")]
+		public Microsoft.Xrm.Sdk.BooleanManagedProperty IsHidden
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("ishidden");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsHidden");
+				this.SetAttributeValue("ishidden", value);
+				this.OnPropertyChanged("IsHidden");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component is managed.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
+		public System.Nullable<bool> IsManaged
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
+			}
+		}
+		
+		/// <summary>
+		/// Information about how the plugin assembly is to be isolated at execution time; None / Sandboxed.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isolationmode")]
+		public System.Nullable<SparkleXrm.Tasks.pluginassembly_isolationmode> IsolationMode
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("isolationmode");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.pluginassembly_isolationmode)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.pluginassembly_isolationmode), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("IsolationMode");
+				if ((value == null))
+				{
+					this.SetAttributeValue("isolationmode", null);
+				}
+				else
+				{
+					this.SetAttributeValue("isolationmode", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("IsolationMode");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ispasswordset")]
+		public System.Nullable<bool> IsPasswordSet
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ispasswordset");
+			}
+		}
+		
+		/// <summary>
+		/// Major of the assembly version.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("major")]
+		public System.Nullable<int> Major
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("major");
+			}
+		}
+		
+		/// <summary>
+		/// Minor of the assembly version.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("minor")]
+		public System.Nullable<int> Minor
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("minor");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who last modified the plug-in assembly.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the plug-in assembly was last modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who last modified the pluginassembly.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Name of the plug-in assembly.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
+		public string Name
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("name");
+			}
+			set
+			{
+				this.OnPropertyChanging("Name");
+				this.SetAttributeValue("name", value);
+				this.OnPropertyChanged("Name");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the organization with which the plug-in assembly is associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
+		public Microsoft.Xrm.Sdk.EntityReference OrganizationId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
+		public System.Nullable<System.DateTime> OverwriteTime
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
+			}
+		}
+		
+		/// <summary>
+		/// User Password
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("password")]
+		public string Password
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("password");
+			}
+			set
+			{
+				this.OnPropertyChanging("Password");
+				this.SetAttributeValue("password", value);
+				this.OnPropertyChanged("Password");
+			}
+		}
+		
+		/// <summary>
+		/// File name of the plug-in assembly. Used when the source type is set to 1.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("path")]
+		public string Path
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("path");
+			}
+			set
+			{
+				this.OnPropertyChanging("Path");
+				this.SetAttributeValue("path", value);
+				this.OnPropertyChanged("Path");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the plug-in assembly.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pluginassemblyid")]
+		public System.Nullable<System.Guid> PluginAssemblyId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("pluginassemblyid");
+			}
+			set
+			{
+				this.OnPropertyChanging("PluginAssemblyId");
+				this.SetAttributeValue("pluginassemblyid", value);
+				if (value.HasValue)
+				{
+					base.Id = value.Value;
+				}
+				else
+				{
+					base.Id = System.Guid.Empty;
+				}
+				this.OnPropertyChanged("PluginAssemblyId");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pluginassemblyid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				this.PluginAssemblyId = value;
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the plug-in assembly.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pluginassemblyidunique")]
+		public System.Nullable<System.Guid> PluginAssemblyIdUnique
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("pluginassemblyidunique");
+			}
+		}
+		
+		/// <summary>
+		/// Public key token of the assembly. This value can be obtained from the assembly by using reflection.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("publickeytoken")]
+		public string PublicKeyToken
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("publickeytoken");
+			}
+			set
+			{
+				this.OnPropertyChanging("PublicKeyToken");
+				this.SetAttributeValue("publickeytoken", value);
+				this.OnPropertyChanged("PublicKeyToken");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the associated solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public System.Nullable<System.Guid> SolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
+			}
+		}
+		
+		/// <summary>
+		/// Hash of the source of the assembly.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sourcehash")]
+		public string SourceHash
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("sourcehash");
+			}
+			set
+			{
+				this.OnPropertyChanging("SourceHash");
+				this.SetAttributeValue("sourcehash", value);
+				this.OnPropertyChanged("SourceHash");
+			}
+		}
+		
+		/// <summary>
+		/// Location of the assembly, for example 0=database, 1=on-disk.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sourcetype")]
+		public System.Nullable<SparkleXrm.Tasks.pluginassembly_sourcetype> SourceType
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("sourcetype");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.pluginassembly_sourcetype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.pluginassembly_sourcetype), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("SourceType");
+				if ((value == null))
+				{
+					this.SetAttributeValue("sourcetype", null);
+				}
+				else
+				{
+					this.SetAttributeValue("sourcetype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("SourceType");
+			}
+		}
+		
+		/// <summary>
+		/// Web Url
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("url")]
+		public string Url
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("url");
+			}
+			set
+			{
+				this.OnPropertyChanging("Url");
+				this.SetAttributeValue("url", value);
+				this.OnPropertyChanged("Url");
+			}
+		}
+		
+		/// <summary>
+		/// User Name
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("username")]
+		public string UserName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("username");
+			}
+			set
+			{
+				this.OnPropertyChanging("UserName");
+				this.SetAttributeValue("username", value);
+				this.OnPropertyChanged("UserName");
+			}
+		}
+		
+		/// <summary>
+		/// Version number of the assembly. The value can be obtained from the assembly through reflection.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("version")]
+		public string Version
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("version");
+			}
+			set
+			{
+				this.OnPropertyChanging("Version");
+				this.SetAttributeValue("version", value);
+				this.OnPropertyChanged("Version");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
+		public System.Nullable<long> VersionNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N pluginassembly_plugintype
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("pluginassembly_plugintype")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.PluginType> pluginassembly_plugintype
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.PluginType>("pluginassembly_plugintype", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("pluginassembly_plugintype");
+				this.SetRelatedEntities<SparkleXrm.Tasks.PluginType>("pluginassembly_plugintype", null, value);
+				this.OnPropertyChanged("pluginassembly_plugintype");
+			}
+		}
+	}
+	
+	/// <summary>
+	/// Type that inherits from the IPlugin interface and is contained within a plug-in assembly.
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("plugintype")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class PluginType : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public PluginType() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "plugintype";
+		
+		public const int EntityTypeCode = 4602;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// Full path name of the plug-in assembly.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("assemblyname")]
+		public string AssemblyName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("assemblyname");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
+		public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the plug-in type was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the plugintype.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Culture code for the plug-in assembly.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("culture")]
+		public string Culture
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("culture");
+			}
+		}
+		
+		/// <summary>
+		/// Customization level of the plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
+		public System.Nullable<int> CustomizationLevel
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
+			}
+		}
+		
+		/// <summary>
+		/// Serialized Custom Activity Type information, including required arguments. For more information, see SandboxCustomActivityInfo.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customworkflowactivityinfo")]
+		public string CustomWorkflowActivityInfo
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("customworkflowactivityinfo");
+			}
+		}
+		
+		/// <summary>
+		/// Description of the plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
+		public string Description
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("description");
+			}
+			set
+			{
+				this.OnPropertyChanging("Description");
+				this.SetAttributeValue("description", value);
+				this.OnPropertyChanged("Description");
+			}
+		}
+		
+		/// <summary>
+		/// User friendly name for the plug-in.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("friendlyname")]
+		public string FriendlyName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("friendlyname");
+			}
+			set
+			{
+				this.OnPropertyChanging("FriendlyName");
+				this.SetAttributeValue("friendlyname", value);
+				this.OnPropertyChanged("FriendlyName");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
+		public System.Nullable<bool> IsManaged
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates if the plug-in is a custom activity for workflows.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isworkflowactivity")]
+		public System.Nullable<bool> IsWorkflowActivity
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isworkflowactivity");
+			}
+            set
+            {
+				this.SetAttributeValue("isworkflowactivity", value);
+			}
+		}
+		
+		/// <summary>
+		/// Major of the version number of the assembly for the plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("major")]
+		public System.Nullable<int> Major
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("major");
+			}
+		}
+		
+		/// <summary>
+		/// Minor of the version number of the assembly for the plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("minor")]
+		public System.Nullable<int> Minor
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("minor");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who last modified the plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the plug-in type was last modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who last modified the plugintype.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Name of the plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
+		public string Name
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("name");
+			}
+			set
+			{
+				this.OnPropertyChanging("Name");
+				this.SetAttributeValue("name", value);
+				this.OnPropertyChanged("Name");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the organization with which the plug-in type is associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
+		public Microsoft.Xrm.Sdk.EntityReference OrganizationId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
+		public System.Nullable<System.DateTime> OverwriteTime
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the plug-in assembly that contains this plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pluginassemblyid")]
+		public Microsoft.Xrm.Sdk.EntityReference PluginAssemblyId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("pluginassemblyid");
+			}
+			set
+			{
+				this.OnPropertyChanging("PluginAssemblyId");
+				this.SetAttributeValue("pluginassemblyid", value);
+				this.OnPropertyChanged("PluginAssemblyId");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("plugintypeid")]
+		public System.Nullable<System.Guid> PluginTypeId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("plugintypeid");
+			}
+			set
+			{
+				this.OnPropertyChanging("PluginTypeId");
+				this.SetAttributeValue("plugintypeid", value);
+				if (value.HasValue)
+				{
+					base.Id = value.Value;
+				}
+				else
+				{
+					base.Id = System.Guid.Empty;
+				}
+				this.OnPropertyChanged("PluginTypeId");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("plugintypeid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				this.PluginTypeId = value;
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("plugintypeidunique")]
+		public System.Nullable<System.Guid> PluginTypeIdUnique
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("plugintypeidunique");
+			}
+		}
+		
+		/// <summary>
+		/// Public key token of the assembly for the plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("publickeytoken")]
+		public string PublicKeyToken
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("publickeytoken");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the associated solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public System.Nullable<System.Guid> SolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
+			}
+		}
+		
+		/// <summary>
+		/// Fully qualified type name of the plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("typename")]
+		public string TypeName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("typename");
+			}
+			set
+			{
+				this.OnPropertyChanging("TypeName");
+				this.SetAttributeValue("typename", value);
+				this.OnPropertyChanged("TypeName");
+			}
+		}
+		
+		/// <summary>
+		/// Version number of the assembly for the plug-in type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("version")]
+		public string Version
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("version");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
+		public System.Nullable<long> VersionNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
+			}
+		}
+		
+		/// <summary>
+		/// Group name of workflow custom activity.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("workflowactivitygroupname")]
+		public string WorkflowActivityGroupName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("workflowactivitygroupname");
+			}
+			set
+			{
+				this.OnPropertyChanging("WorkflowActivityGroupName");
+				this.SetAttributeValue("workflowactivitygroupname", value);
+				this.OnPropertyChanged("WorkflowActivityGroupName");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N plugintype_customapi
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("plugintype_customapi")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.CustomAPI> plugintype_customapi
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.CustomAPI>("plugintype_customapi", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("plugintype_customapi");
+				this.SetRelatedEntities<SparkleXrm.Tasks.CustomAPI>("plugintype_customapi", null, value);
+				this.OnPropertyChanged("plugintype_customapi");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N plugintype_sdkmessageprocessingstep
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("plugintype_sdkmessageprocessingstep")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStep> plugintype_sdkmessageprocessingstep
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("plugintype_sdkmessageprocessingstep", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("plugintype_sdkmessageprocessingstep");
+				this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("plugintype_sdkmessageprocessingstep", null, value);
+				this.OnPropertyChanged("plugintype_sdkmessageprocessingstep");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N plugintypeid_sdkmessageprocessingstep
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("plugintypeid_sdkmessageprocessingstep")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStep> plugintypeid_sdkmessageprocessingstep
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("plugintypeid_sdkmessageprocessingstep", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("plugintypeid_sdkmessageprocessingstep");
+				this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("plugintypeid_sdkmessageprocessingstep", null, value);
+				this.OnPropertyChanged("plugintypeid_sdkmessageprocessingstep");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 pluginassembly_plugintype
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pluginassemblyid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("pluginassembly_plugintype")]
+		public SparkleXrm.Tasks.PluginAssembly pluginassembly_plugintype
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.PluginAssembly>("pluginassembly_plugintype", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("pluginassembly_plugintype");
+				this.SetRelatedEntity<SparkleXrm.Tasks.PluginAssembly>("pluginassembly_plugintype", null, value);
+				this.OnPropertyChanged("pluginassembly_plugintype");
+			}
+		}
+	}
+	
+	/// <summary>
+	/// Message that is supported by the SDK.
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("sdkmessage")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class SdkMessage : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public SdkMessage() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "sdkmessage";
+		
+		public const int EntityTypeCode = 4606;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// Information about whether the SDK message is automatically transacted.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("autotransact")]
+		public System.Nullable<bool> AutoTransact
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("autotransact");
+			}
+			set
+			{
+				this.OnPropertyChanging("AutoTransact");
+				this.SetAttributeValue("autotransact", value);
+				this.OnPropertyChanged("AutoTransact");
+			}
+		}
+		
+		/// <summary>
+		/// Identifies where a method will be exposed. 0 - Server, 1 - Client, 2 - both.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("availability")]
+		public System.Nullable<int> Availability
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("availability");
+			}
+			set
+			{
+				this.OnPropertyChanging("Availability");
+				this.SetAttributeValue("availability", value);
+				this.OnPropertyChanged("Availability");
+			}
+		}
+		
+		/// <summary>
+		/// If this is a categorized method, this is the name, otherwise None.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("categoryname")]
+		public string CategoryName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("categoryname");
+			}
+			set
+			{
+				this.OnPropertyChanging("CategoryName");
+				this.SetAttributeValue("categoryname", value);
+				this.OnPropertyChanged("CategoryName");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
+		public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the SDK message.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the SDK message was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the sdkmessage.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Customization level of the SDK message.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
+		public System.Nullable<int> CustomizationLevel
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
+			}
+		}
+		
+		/// <summary>
+		/// Name of the privilege that allows execution of the SDK message
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("executeprivilegename")]
+		public string ExecutePrivilegeName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("executeprivilegename");
+			}
+			set
+			{
+				this.OnPropertyChanging("ExecutePrivilegeName");
+				this.SetAttributeValue("executeprivilegename", value);
+				this.OnPropertyChanged("ExecutePrivilegeName");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates whether the SDK message should have its requests expanded per primary entity defined in its filters.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("expand")]
+		public System.Nullable<bool> Expand
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("expand");
+			}
+			set
+			{
+				this.OnPropertyChanging("Expand");
+				this.SetAttributeValue("expand", value);
+				this.OnPropertyChanged("Expand");
+			}
+		}
+		
+		/// <summary>
+		/// Version in which the component is introduced.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
+		public string IntroducedVersion
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("introducedversion");
+			}
+			set
+			{
+				this.OnPropertyChanging("IntroducedVersion");
+				this.SetAttributeValue("introducedversion", value);
+				this.OnPropertyChanged("IntroducedVersion");
+			}
+		}
+		
+		/// <summary>
+		/// Information about whether the SDK message is active.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isactive")]
+		public System.Nullable<bool> IsActive
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isactive");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsActive");
+				this.SetAttributeValue("isactive", value);
+				this.OnPropertyChanged("IsActive");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component is managed.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
+		public System.Nullable<bool> IsManaged
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates whether the SDK message is private.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isprivate")]
+		public System.Nullable<bool> IsPrivate
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isprivate");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsPrivate");
+				this.SetAttributeValue("isprivate", value);
+				this.OnPropertyChanged("IsPrivate");
+			}
+		}
+		
+		/// <summary>
+		/// Identifies whether an SDK message will be ReadOnly or Read Write. false - ReadWrite, true - ReadOnly .
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isreadonly")]
+		public System.Nullable<bool> IsReadOnly
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isreadonly");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsReadOnly");
+				this.SetAttributeValue("isreadonly", value);
+				this.OnPropertyChanged("IsReadOnly");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isvalidforexecuteasync")]
+		public System.Nullable<bool> IsValidForExecuteAsync
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isvalidforexecuteasync");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who last modified the SDK message.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the SDK message was last modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who last modified the sdkmessage.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Name of the SDK message.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
+		public string Name
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("name");
+			}
+			set
+			{
+				this.OnPropertyChanging("Name");
+				this.SetAttributeValue("name", value);
+				this.OnPropertyChanged("Name");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the organization with which the SDK message is associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
+		public Microsoft.Xrm.Sdk.EntityReference OrganizationId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
+		public System.Nullable<System.DateTime> OverwriteTime
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message entity.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
+		public System.Nullable<System.Guid> SdkMessageId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessageId");
+				this.SetAttributeValue("sdkmessageid", value);
+				if (value.HasValue)
+				{
+					base.Id = value.Value;
+				}
+				else
+				{
+					base.Id = System.Guid.Empty;
+				}
+				this.OnPropertyChanged("SdkMessageId");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				this.SdkMessageId = value;
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageidunique")]
+		public System.Nullable<System.Guid> SdkMessageIdUnique
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageidunique");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the associated solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public System.Nullable<System.Guid> SolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates whether the SDK message is a template.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("template")]
+		public System.Nullable<bool> Template
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("template");
+			}
+			set
+			{
+				this.OnPropertyChanging("Template");
+				this.SetAttributeValue("template", value);
+				this.OnPropertyChanged("Template");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("throttlesettings")]
+		public string ThrottleSettings
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("throttlesettings");
+			}
+		}
+		
+		/// <summary>
+		/// Number that identifies a specific revision of the SDK message. 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
+		public System.Nullable<long> VersionNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
+			}
+		}
+		
+		/// <summary>
+		/// Whether or not the SDK message can be called from a workflow.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("workflowsdkstepenabled")]
+		public System.Nullable<bool> WorkflowSdkStepEnabled
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("workflowsdkstepenabled");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N message_sdkmessagepair
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("message_sdkmessagepair")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessagePair> message_sdkmessagepair
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessagePair>("message_sdkmessagepair", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("message_sdkmessagepair");
+				this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessagePair>("message_sdkmessagepair", null, value);
+				this.OnPropertyChanged("message_sdkmessagepair");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N sdkmessage_customapi
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessage_customapi")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.CustomAPI> sdkmessage_customapi
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.CustomAPI>("sdkmessage_customapi", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("sdkmessage_customapi");
+				this.SetRelatedEntities<SparkleXrm.Tasks.CustomAPI>("sdkmessage_customapi", null, value);
+				this.OnPropertyChanged("sdkmessage_customapi");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N sdkmessageid_sdkmessagefilter
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageid_sdkmessagefilter")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageFilter> sdkmessageid_sdkmessagefilter
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageFilter>("sdkmessageid_sdkmessagefilter", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("sdkmessageid_sdkmessagefilter");
+				this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageFilter>("sdkmessageid_sdkmessagefilter", null, value);
+				this.OnPropertyChanged("sdkmessageid_sdkmessagefilter");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N sdkmessageid_sdkmessageprocessingstep
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageid_sdkmessageprocessingstep")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStep> sdkmessageid_sdkmessageprocessingstep
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessageid_sdkmessageprocessingstep", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("sdkmessageid_sdkmessageprocessingstep");
+				this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessageid_sdkmessageprocessingstep", null, value);
+				this.OnPropertyChanged("sdkmessageid_sdkmessageprocessingstep");
+			}
+		}
+	}
+	
+	/// <summary>
+	/// Filter that defines which SDK messages are valid for each type of entity.
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("sdkmessagefilter")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class SdkMessageFilter : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public SdkMessageFilter() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "sdkmessagefilter";
+		
+		public const int EntityTypeCode = 4607;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// Identifies where a method will be exposed. 0 - Server, 1 - Client, 2 - both.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("availability")]
+		public System.Nullable<int> Availability
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("availability");
+			}
+			set
+			{
+				this.OnPropertyChanging("Availability");
+				this.SetAttributeValue("availability", value);
+				this.OnPropertyChanged("Availability");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
+		public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the SDK message filter.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the SDK message filter was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the sdkmessagefilter.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Customization level of the SDK message filter.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
+		public System.Nullable<int> CustomizationLevel
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
+			}
+		}
+		
+		/// <summary>
+		/// Version in which the component is introduced.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
+		public string IntroducedVersion
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("introducedversion");
+			}
+			set
+			{
+				this.OnPropertyChanging("IntroducedVersion");
+				this.SetAttributeValue("introducedversion", value);
+				this.OnPropertyChanged("IntroducedVersion");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates whether a custom SDK message processing step is allowed.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomprocessingstepallowed")]
+		public System.Nullable<bool> IsCustomProcessingStepAllowed
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("iscustomprocessingstepallowed");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsCustomProcessingStepAllowed");
+				this.SetAttributeValue("iscustomprocessingstepallowed", value);
+				this.OnPropertyChanged("IsCustomProcessingStepAllowed");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component is managed.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
+		public System.Nullable<bool> IsManaged
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates whether the filter should be visible.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isvisible")]
+		public System.Nullable<bool> IsVisible
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isvisible");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who last modified the SDK message filter.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the SDK message filter was last modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who last modified the sdkmessagefilter.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Name of the SDK message filter.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
+		public string Name
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("name");
+			}
+			set
+			{
+				this.OnPropertyChanging("Name");
+				this.SetAttributeValue("name", value);
+				this.OnPropertyChanged("Name");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the organization with which the SDK message filter is associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
+		public Microsoft.Xrm.Sdk.EntityReference OrganizationId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
+		public System.Nullable<System.DateTime> OverwriteTime
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
+			}
+		}
+		
+		/// <summary>
+		/// Type of entity with which the SDK message filter is primarily associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("primaryobjecttypecode")]
+		public string PrimaryObjectTypeCode
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("primaryobjecttypecode");
+			}
+            set
+            {
+				this.SetAttributeValue("primaryobjecttypecode", value);
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("restrictionlevel")]
+		public System.Nullable<int> RestrictionLevel
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("restrictionlevel");
+			}
+			set
+			{
+				this.OnPropertyChanging("RestrictionLevel");
+				this.SetAttributeValue("restrictionlevel", value);
+				this.OnPropertyChanged("RestrictionLevel");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message filter entity.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagefilterid")]
+		public System.Nullable<System.Guid> SdkMessageFilterId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessagefilterid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessageFilterId");
+				this.SetAttributeValue("sdkmessagefilterid", value);
+				if (value.HasValue)
+				{
+					base.Id = value.Value;
+				}
+				else
+				{
+					base.Id = System.Guid.Empty;
+				}
+				this.OnPropertyChanged("SdkMessageFilterId");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagefilterid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				this.SdkMessageFilterId = value;
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message filter.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagefilteridunique")]
+		public System.Nullable<System.Guid> SdkMessageFilterIdUnique
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessagefilteridunique");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the related SDK message.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
+		public Microsoft.Xrm.Sdk.EntityReference SdkMessageId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessageid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessageId");
+				this.SetAttributeValue("sdkmessageid", value);
+				this.OnPropertyChanged("SdkMessageId");
+			}
+		}
+		
+		/// <summary>
+		/// Type of entity with which the SDK message filter is secondarily associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("secondaryobjecttypecode")]
+		public string SecondaryObjectTypeCode
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("secondaryobjecttypecode");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the associated solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public System.Nullable<System.Guid> SolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
+		public System.Nullable<long> VersionNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
+			}
+		}
+		
+		/// <summary>
+		/// Whether or not the SDK message can be called from a workflow.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("workflowsdkstepenabled")]
+		public System.Nullable<bool> WorkflowSdkStepEnabled
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("workflowsdkstepenabled");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N sdkmessagefilterid_sdkmessageprocessingstep
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessagefilterid_sdkmessageprocessingstep")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStep> sdkmessagefilterid_sdkmessageprocessingstep
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessagefilterid_sdkmessageprocessingstep", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("sdkmessagefilterid_sdkmessageprocessingstep");
+				this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessagefilterid_sdkmessageprocessingstep", null, value);
+				this.OnPropertyChanged("sdkmessagefilterid_sdkmessageprocessingstep");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 sdkmessageid_sdkmessagefilter
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageid_sdkmessagefilter")]
+		public SparkleXrm.Tasks.SdkMessage sdkmessageid_sdkmessagefilter
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessage>("sdkmessageid_sdkmessagefilter", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("sdkmessageid_sdkmessagefilter");
+				this.SetRelatedEntity<SparkleXrm.Tasks.SdkMessage>("sdkmessageid_sdkmessagefilter", null, value);
+				this.OnPropertyChanged("sdkmessageid_sdkmessagefilter");
+			}
+		}
+	}
+	
+	/// <summary>
+	/// For internal use only.
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("sdkmessagepair")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class SdkMessagePair : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public SdkMessagePair() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "sdkmessagepair";
+		
+		public const int EntityTypeCode = 4613;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
+		public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the SDK message pair.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the SDK message pair was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the sdkmessagepair.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Customization level of the SDK message filter.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
+		public System.Nullable<int> CustomizationLevel
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
+			}
+		}
+		
+		/// <summary>
+		/// Version in which the component is deprecated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("deprecatedversion")]
+		public string DeprecatedVersion
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("deprecatedversion");
+			}
+			set
+			{
+				this.OnPropertyChanging("DeprecatedVersion");
+				this.SetAttributeValue("deprecatedversion", value);
+				this.OnPropertyChanged("DeprecatedVersion");
+			}
+		}
+		
+		/// <summary>
+		/// Endpoint that the message pair is associated with.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("endpoint")]
+		public string Endpoint
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("endpoint");
+			}
+			set
+			{
+				this.OnPropertyChanging("Endpoint");
+				this.SetAttributeValue("endpoint", value);
+				this.OnPropertyChanged("Endpoint");
+			}
+		}
+		
+		/// <summary>
+		/// Version in which the component is introduced.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
+		public string IntroducedVersion
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("introducedversion");
+			}
+			set
+			{
+				this.OnPropertyChanging("IntroducedVersion");
+				this.SetAttributeValue("introducedversion", value);
+				this.OnPropertyChanged("IntroducedVersion");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component is managed.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
+		public System.Nullable<bool> IsManaged
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who last modified the SDK message pair.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the SDK message pair was last modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who last modified the sdkmessagepair.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Namespace that the message pair is associated with.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("namespace")]
+		public string Namespace
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("namespace");
+			}
+			set
+			{
+				this.OnPropertyChanging("Namespace");
+				this.SetAttributeValue("namespace", value);
+				this.OnPropertyChanged("Namespace");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the organization with which the SDK message pair is associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
+		public Microsoft.Xrm.Sdk.EntityReference OrganizationId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
+		public System.Nullable<System.DateTime> OverwriteTime
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagebindinginformation")]
+		public string SdkMessageBindingInformation
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("sdkmessagebindinginformation");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessageBindingInformation");
+				this.SetAttributeValue("sdkmessagebindinginformation", value);
+				this.OnPropertyChanged("SdkMessageBindingInformation");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the message with which the SDK message pair is associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
+		public Microsoft.Xrm.Sdk.EntityReference SdkMessageId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessageid");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message pair entity.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagepairid")]
+		public System.Nullable<System.Guid> SdkMessagePairId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessagepairid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessagePairId");
+				this.SetAttributeValue("sdkmessagepairid", value);
+				if (value.HasValue)
+				{
+					base.Id = value.Value;
+				}
+				else
+				{
+					base.Id = System.Guid.Empty;
+				}
+				this.OnPropertyChanged("SdkMessagePairId");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagepairid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				this.SdkMessagePairId = value;
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message pair.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagepairidunique")]
+		public System.Nullable<System.Guid> SdkMessagePairIdUnique
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessagepairidunique");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the associated solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public System.Nullable<System.Guid> SolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
+		public System.Nullable<long> VersionNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 message_sdkmessagepair
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("message_sdkmessagepair")]
+		public SparkleXrm.Tasks.SdkMessage message_sdkmessagepair
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessage>("message_sdkmessagepair", null);
+			}
+		}
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum sdkmessageprocessingstep_invocationsource
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Internal = -1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Parent = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Child = 1,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum sdkmessageprocessingstep_mode
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Synchronous = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Asynchronous = 1,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum sdkmessageprocessingstep_stage
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		InitialPreoperation_Forinternaluseonly = 5,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Prevalidation = 10,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		InternalPreoperationBeforeExternalPlugins_Forinternaluseonly = 15,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Preoperation = 20,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		InternalPreoperationAfterExternalPlugins_Forinternaluseonly = 25,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		MainOperation_Forinternaluseonly = 30,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		InternalPostoperationBeforeExternalPlugins_Forinternaluseonly = 35,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Postoperation = 40,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		InternalPostoperationAfterExternalPlugins_Forinternaluseonly = 45,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Postoperation_Deprecated = 50,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		FinalPostoperation_Forinternaluseonly = 55,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		PreCommitstagefiredbeforetransactioncommit_Forinternaluseonly = 80,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		PostCommitstagefiredaftertransactioncommit_Forinternaluseonly = 90,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum SdkMessageProcessingStepState
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Enabled = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Disabled = 1,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum sdkmessageprocessingstep_statuscode
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Enabled = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Disabled = 2,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum sdkmessageprocessingstep_supporteddeployment
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		ServerOnly = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		MicrosoftDynamics365ClientforOutlookOnly = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Both = 2,
+	}
+	
+	/// <summary>
+	/// Stage in the execution pipeline that a plug-in is to execute.
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("sdkmessageprocessingstep")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class SdkMessageProcessingStep : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public SdkMessageProcessingStep() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "sdkmessageprocessingstep";
+		
+		public const int EntityTypeCode = 4608;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// Indicates whether the asynchronous system job is automatically deleted on completion.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("asyncautodelete")]
+		public System.Nullable<bool> AsyncAutoDelete
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("asyncautodelete");
+			}
+			set
+			{
+				this.OnPropertyChanging("AsyncAutoDelete");
+				this.SetAttributeValue("asyncautodelete", value);
+				this.OnPropertyChanged("AsyncAutoDelete");
+			}
+		}
+		
+		/// <summary>
+		/// Identifies whether a SDK Message Processing Step type will be ReadOnly or Read Write. false - ReadWrite, true - ReadOnly 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("canusereadonlyconnection")]
+		public System.Nullable<bool> CanUseReadOnlyConnection
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("canusereadonlyconnection");
+			}
+			set
+			{
+				this.OnPropertyChanging("CanUseReadOnlyConnection");
+				this.SetAttributeValue("canusereadonlyconnection", value);
+				this.OnPropertyChanged("CanUseReadOnlyConnection");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
+		public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
+			}
+		}
+		
+		/// <summary>
+		/// Step-specific configuration for the plug-in type. Passed to the plug-in constructor at run time.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("configuration")]
+		public string Configuration
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("configuration");
+			}
+			set
+			{
+				this.OnPropertyChanging("Configuration");
+				this.SetAttributeValue("configuration", value);
+				this.OnPropertyChanged("Configuration");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the SDK message processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the SDK message processing step was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the sdkmessageprocessingstep.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Customization level of the SDK message processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
+		public System.Nullable<int> CustomizationLevel
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
+			}
+		}
+		
+		/// <summary>
+		/// Description of the SDK message processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
+		public string Description
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("description");
+			}
+			set
+			{
+				this.OnPropertyChanging("Description");
+				this.SetAttributeValue("description", value);
+				this.OnPropertyChanged("Description");
+			}
+		}
+		
+		/// <summary>
+		/// Configuration for sending pipeline events to the Event Expander service.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("eventexpander")]
+		public string EventExpander
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("eventexpander");
+			}
+			set
+			{
+				this.OnPropertyChanging("EventExpander");
+				this.SetAttributeValue("eventexpander", value);
+				this.OnPropertyChanged("EventExpander");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the associated event handler.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("eventhandler")]
+		public Microsoft.Xrm.Sdk.EntityReference EventHandler
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("eventhandler");
+			}
+			set
+			{
+				this.OnPropertyChanging("EventHandler");
+				this.SetAttributeValue("eventhandler", value);
+				this.OnPropertyChanged("EventHandler");
+			}
+		}
+		
+		/// <summary>
+		/// Comma-separated list of attributes. If at least one of these attributes is modified, the plug-in should execute.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("filteringattributes")]
+		public string FilteringAttributes
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("filteringattributes");
+			}
+			set
+			{
+				this.OnPropertyChanging("FilteringAttributes");
+				this.SetAttributeValue("filteringattributes", value);
+				this.OnPropertyChanged("FilteringAttributes");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user to impersonate context when step is executed.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("impersonatinguserid")]
+		public Microsoft.Xrm.Sdk.EntityReference ImpersonatingUserId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("impersonatinguserid");
+			}
+			set
+			{
+				this.OnPropertyChanging("ImpersonatingUserId");
+				this.SetAttributeValue("impersonatinguserid", value);
+				this.OnPropertyChanged("ImpersonatingUserId");
+			}
+		}
+		
+		/// <summary>
+		/// Version in which the form is introduced.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
+		public string IntroducedVersion
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("introducedversion");
+			}
+			set
+			{
+				this.OnPropertyChanging("IntroducedVersion");
+				this.SetAttributeValue("introducedversion", value);
+				this.OnPropertyChanged("IntroducedVersion");
+			}
+		}
+		
+		/// <summary>
+		/// Identifies if a plug-in should be executed from a parent pipeline, a child pipeline, or both.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("invocationsource")]
+		[System.ObsoleteAttribute()]
+		public System.Nullable<SparkleXrm.Tasks.sdkmessageprocessingstep_invocationsource> InvocationSource
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("invocationsource");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.sdkmessageprocessingstep_invocationsource)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.sdkmessageprocessingstep_invocationsource), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("InvocationSource");
+				if ((value == null))
+				{
+					this.SetAttributeValue("invocationsource", null);
+				}
+				else
+				{
+					this.SetAttributeValue("invocationsource", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("InvocationSource");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component can be customized.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomizable")]
+		public Microsoft.Xrm.Sdk.BooleanManagedProperty IsCustomizable
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("iscustomizable");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsCustomizable");
+				this.SetAttributeValue("iscustomizable", value);
+				this.OnPropertyChanged("IsCustomizable");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component should be hidden.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ishidden")]
+		public Microsoft.Xrm.Sdk.BooleanManagedProperty IsHidden
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("ishidden");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsHidden");
+				this.SetAttributeValue("ishidden", value);
+				this.OnPropertyChanged("IsHidden");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component is managed.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
+		public System.Nullable<bool> IsManaged
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
+			}
+		}
+		
+		/// <summary>
+		/// Run-time mode of execution, for example, synchronous or asynchronous.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("mode")]
+		public System.Nullable<SparkleXrm.Tasks.sdkmessageprocessingstep_mode> Mode
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("mode");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.sdkmessageprocessingstep_mode)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.sdkmessageprocessingstep_mode), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("Mode");
+				if ((value == null))
+				{
+					this.SetAttributeValue("mode", null);
+				}
+				else
+				{
+					this.SetAttributeValue("mode", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("Mode");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who last modified the SDK message processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the SDK message processing step was last modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who last modified the sdkmessageprocessingstep.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Name of SdkMessage processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
+		public string Name
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("name");
+			}
+			set
+			{
+				this.OnPropertyChanging("Name");
+				this.SetAttributeValue("name", value);
+				this.OnPropertyChanged("Name");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the organization with which the SDK message processing step is associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
+		public Microsoft.Xrm.Sdk.EntityReference OrganizationId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
+		public System.Nullable<System.DateTime> OverwriteTime
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the plug-in type associated with the step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("plugintypeid")]
+		[System.ObsoleteAttribute()]
+		public Microsoft.Xrm.Sdk.EntityReference PluginTypeId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("plugintypeid");
+			}
+			set
+			{
+				this.OnPropertyChanging("PluginTypeId");
+				this.SetAttributeValue("plugintypeid", value);
+				this.OnPropertyChanged("PluginTypeId");
+			}
+		}
+		
+		/// <summary>
+		/// Processing order within the stage.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("rank")]
+		public System.Nullable<int> Rank
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("rank");
+			}
+			set
+			{
+				this.OnPropertyChanging("Rank");
+				this.SetAttributeValue("rank", value);
+				this.OnPropertyChanged("Rank");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message filter.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagefilterid")]
+		public Microsoft.Xrm.Sdk.EntityReference SdkMessageFilterId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessagefilterid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessageFilterId");
+				this.SetAttributeValue("sdkmessagefilterid", value);
+				this.OnPropertyChanged("SdkMessageFilterId");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
+		public Microsoft.Xrm.Sdk.EntityReference SdkMessageId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessageid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessageId");
+				this.SetAttributeValue("sdkmessageid", value);
+				this.OnPropertyChanged("SdkMessageId");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message processing step entity.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepid")]
+		public System.Nullable<System.Guid> SdkMessageProcessingStepId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageprocessingstepid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessageProcessingStepId");
+				this.SetAttributeValue("sdkmessageprocessingstepid", value);
+				if (value.HasValue)
+				{
+					base.Id = value.Value;
+				}
+				else
+				{
+					base.Id = System.Guid.Empty;
+				}
+				this.OnPropertyChanged("SdkMessageProcessingStepId");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				this.SdkMessageProcessingStepId = value;
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepidunique")]
+		public System.Nullable<System.Guid> SdkMessageProcessingStepIdUnique
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageprocessingstepidunique");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the Sdk message processing step secure configuration.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepsecureconfigid")]
+		public Microsoft.Xrm.Sdk.EntityReference SdkMessageProcessingStepSecureConfigId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessageprocessingstepsecureconfigid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessageProcessingStepSecureConfigId");
+				this.SetAttributeValue("sdkmessageprocessingstepsecureconfigid", value);
+				this.OnPropertyChanged("SdkMessageProcessingStepSecureConfigId");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the associated solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public System.Nullable<System.Guid> SolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
+			}
+		}
+		
+		/// <summary>
+		/// Stage in the execution pipeline that the SDK message processing step is in.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("stage")]
+		public System.Nullable<SparkleXrm.Tasks.sdkmessageprocessingstep_stage> Stage
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("stage");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.sdkmessageprocessingstep_stage)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.sdkmessageprocessingstep_stage), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("Stage");
+				if ((value == null))
+				{
+					this.SetAttributeValue("stage", null);
+				}
+				else
+				{
+					this.SetAttributeValue("stage", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("Stage");
+			}
+		}
+		
+		/// <summary>
+		/// Status of the SDK message processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("statecode")]
+		public System.Nullable<SparkleXrm.Tasks.SdkMessageProcessingStepState> StateCode
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("statecode");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.SdkMessageProcessingStepState)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.SdkMessageProcessingStepState), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("StateCode");
+				if ((value == null))
+				{
+					this.SetAttributeValue("statecode", null);
+				}
+				else
+				{
+					this.SetAttributeValue("statecode", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("StateCode");
+			}
+		}
+		
+		/// <summary>
+		/// Reason for the status of the SDK message processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("statuscode")]
+		public System.Nullable<SparkleXrm.Tasks.sdkmessageprocessingstep_statuscode> StatusCode
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("statuscode");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.sdkmessageprocessingstep_statuscode)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.sdkmessageprocessingstep_statuscode), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("StatusCode");
+				if ((value == null))
+				{
+					this.SetAttributeValue("statuscode", null);
+				}
+				else
+				{
+					this.SetAttributeValue("statuscode", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("StatusCode");
+			}
+		}
+		
+		/// <summary>
+		/// Deployment that the SDK message processing step should be executed on; server, client, or both.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("supporteddeployment")]
+		public System.Nullable<SparkleXrm.Tasks.sdkmessageprocessingstep_supporteddeployment> SupportedDeployment
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("supporteddeployment");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.sdkmessageprocessingstep_supporteddeployment)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.sdkmessageprocessingstep_supporteddeployment), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("SupportedDeployment");
+				if ((value == null))
+				{
+					this.SetAttributeValue("supporteddeployment", null);
+				}
+				else
+				{
+					this.SetAttributeValue("supporteddeployment", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("SupportedDeployment");
+			}
+		}
+		
+		/// <summary>
+		/// Number that identifies a specific revision of the SDK message processing step. 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
+		public System.Nullable<long> VersionNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N sdkmessageprocessingstepid_sdkmessageprocessingstepimage
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageprocessingstepid_sdkmessageprocessingstepimage")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStepImage> sdkmessageprocessingstepid_sdkmessageprocessingstepimage
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStepImage>("sdkmessageprocessingstepid_sdkmessageprocessingstepimage", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("sdkmessageprocessingstepid_sdkmessageprocessingstepimage");
+				this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStepImage>("sdkmessageprocessingstepid_sdkmessageprocessingstepimage", null, value);
+				this.OnPropertyChanged("sdkmessageprocessingstepid_sdkmessageprocessingstepimage");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 plugintype_sdkmessageprocessingstep
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("eventhandler")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("plugintype_sdkmessageprocessingstep")]
+		public SparkleXrm.Tasks.PluginType plugintype_sdkmessageprocessingstep
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.PluginType>("plugintype_sdkmessageprocessingstep", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("plugintype_sdkmessageprocessingstep");
+				this.SetRelatedEntity<SparkleXrm.Tasks.PluginType>("plugintype_sdkmessageprocessingstep", null, value);
+				this.OnPropertyChanged("plugintype_sdkmessageprocessingstep");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 plugintypeid_sdkmessageprocessingstep
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("plugintypeid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("plugintypeid_sdkmessageprocessingstep")]
+		public SparkleXrm.Tasks.PluginType plugintypeid_sdkmessageprocessingstep
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.PluginType>("plugintypeid_sdkmessageprocessingstep", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("plugintypeid_sdkmessageprocessingstep");
+				this.SetRelatedEntity<SparkleXrm.Tasks.PluginType>("plugintypeid_sdkmessageprocessingstep", null, value);
+				this.OnPropertyChanged("plugintypeid_sdkmessageprocessingstep");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 sdkmessagefilterid_sdkmessageprocessingstep
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessagefilterid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessagefilterid_sdkmessageprocessingstep")]
+		public SparkleXrm.Tasks.SdkMessageFilter sdkmessagefilterid_sdkmessageprocessingstep
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessageFilter>("sdkmessagefilterid_sdkmessageprocessingstep", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("sdkmessagefilterid_sdkmessageprocessingstep");
+				this.SetRelatedEntity<SparkleXrm.Tasks.SdkMessageFilter>("sdkmessagefilterid_sdkmessageprocessingstep", null, value);
+				this.OnPropertyChanged("sdkmessagefilterid_sdkmessageprocessingstep");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 sdkmessageid_sdkmessageprocessingstep
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageid_sdkmessageprocessingstep")]
+		public SparkleXrm.Tasks.SdkMessage sdkmessageid_sdkmessageprocessingstep
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessage>("sdkmessageid_sdkmessageprocessingstep", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("sdkmessageid_sdkmessageprocessingstep");
+				this.SetRelatedEntity<SparkleXrm.Tasks.SdkMessage>("sdkmessageid_sdkmessageprocessingstep", null, value);
+				this.OnPropertyChanged("sdkmessageid_sdkmessageprocessingstep");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepsecureconfigid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep")]
+		public SparkleXrm.Tasks.SdkMessageProcessingStepSecureConfig sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessageProcessingStepSecureConfig>("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep");
+				this.SetRelatedEntity<SparkleXrm.Tasks.SdkMessageProcessingStepSecureConfig>("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep", null, value);
+				this.OnPropertyChanged("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 serviceendpoint_sdkmessageprocessingstep
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("eventhandler")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("serviceendpoint_sdkmessageprocessingstep")]
+		public SparkleXrm.Tasks.ServiceEndpoint serviceendpoint_sdkmessageprocessingstep
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.ServiceEndpoint>("serviceendpoint_sdkmessageprocessingstep", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("serviceendpoint_sdkmessageprocessingstep");
+				this.SetRelatedEntity<SparkleXrm.Tasks.ServiceEndpoint>("serviceendpoint_sdkmessageprocessingstep", null, value);
+				this.OnPropertyChanged("serviceendpoint_sdkmessageprocessingstep");
+			}
+		}
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum sdkmessageprocessingstepimage_imagetype
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		PreImage = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		PostImage = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Both = 2,
+	}
+	
+	/// <summary>
+	/// Copy of an entity's attributes before or after the core system operation.
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("sdkmessageprocessingstepimage")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class SdkMessageProcessingStepImage : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public SdkMessageProcessingStepImage() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "sdkmessageprocessingstepimage";
+		
+		public const int EntityTypeCode = 4615;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// Comma-separated list of attributes that are to be passed into the SDK message processing step image.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("attributes")]
+		public string Attributes1
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("attributes");
+			}
+			set
+			{
+				this.OnPropertyChanging("Attributes1");
+				this.SetAttributeValue("attributes", value);
+				this.OnPropertyChanged("Attributes1");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
+		public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the SDK message processing step image.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the SDK message processing step image was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the sdkmessageprocessingstepimage.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Customization level of the SDK message processing step image.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
+		public System.Nullable<int> CustomizationLevel
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
+			}
+		}
+		
+		/// <summary>
+		/// Description of the SDK message processing step image.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
+		public string Description
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("description");
+			}
+			set
+			{
+				this.OnPropertyChanging("Description");
+				this.SetAttributeValue("description", value);
+				this.OnPropertyChanged("Description");
+			}
+		}
+		
+		/// <summary>
+		/// Key name used to access the pre-image or post-image property bags in a step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("entityalias")]
+		public string EntityAlias
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("entityalias");
+			}
+			set
+			{
+				this.OnPropertyChanging("EntityAlias");
+				this.SetAttributeValue("entityalias", value);
+				this.OnPropertyChanged("EntityAlias");
+			}
+		}
+		
+		/// <summary>
+		/// Type of image requested.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("imagetype")]
+		public System.Nullable<SparkleXrm.Tasks.sdkmessageprocessingstepimage_imagetype> ImageType
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("imagetype");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.sdkmessageprocessingstepimage_imagetype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.sdkmessageprocessingstepimage_imagetype), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("ImageType");
+				if ((value == null))
+				{
+					this.SetAttributeValue("imagetype", null);
+				}
+				else
+				{
+					this.SetAttributeValue("imagetype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("ImageType");
+			}
+		}
+		
+		/// <summary>
+		/// Version in which the form is introduced.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
+		public string IntroducedVersion
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("introducedversion");
+			}
+			set
+			{
+				this.OnPropertyChanging("IntroducedVersion");
+				this.SetAttributeValue("introducedversion", value);
+				this.OnPropertyChanged("IntroducedVersion");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component can be customized.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomizable")]
+		public Microsoft.Xrm.Sdk.BooleanManagedProperty IsCustomizable
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("iscustomizable");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsCustomizable");
+				this.SetAttributeValue("iscustomizable", value);
+				this.OnPropertyChanged("IsCustomizable");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
+		public System.Nullable<bool> IsManaged
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
+			}
+		}
+		
+		/// <summary>
+		/// Name of the property on the Request message.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("messagepropertyname")]
+		public string MessagePropertyName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("messagepropertyname");
+			}
+			set
+			{
+				this.OnPropertyChanging("MessagePropertyName");
+				this.SetAttributeValue("messagepropertyname", value);
+				this.OnPropertyChanged("MessagePropertyName");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who last modified the SDK message processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the SDK message processing step was last modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who last modified the sdkmessageprocessingstepimage.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Name of SdkMessage processing step image.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
+		public string Name
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("name");
+			}
+			set
+			{
+				this.OnPropertyChanging("Name");
+				this.SetAttributeValue("name", value);
+				this.OnPropertyChanged("Name");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the organization with which the SDK message processing step is associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
+		public Microsoft.Xrm.Sdk.EntityReference OrganizationId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
+		public System.Nullable<System.DateTime> OverwriteTime
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
+			}
+		}
+		
+		/// <summary>
+		/// Name of the related entity.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("relatedattributename")]
+		public string RelatedAttributeName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("relatedattributename");
+			}
+			set
+			{
+				this.OnPropertyChanging("RelatedAttributeName");
+				this.SetAttributeValue("relatedattributename", value);
+				this.OnPropertyChanged("RelatedAttributeName");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepid")]
+		public Microsoft.Xrm.Sdk.EntityReference SdkMessageProcessingStepId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("sdkmessageprocessingstepid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessageProcessingStepId");
+				this.SetAttributeValue("sdkmessageprocessingstepid", value);
+				this.OnPropertyChanged("SdkMessageProcessingStepId");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message processing step image entity.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepimageid")]
+		public System.Nullable<System.Guid> SdkMessageProcessingStepImageId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageprocessingstepimageid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessageProcessingStepImageId");
+				this.SetAttributeValue("sdkmessageprocessingstepimageid", value);
+				if (value.HasValue)
+				{
+					base.Id = value.Value;
+				}
+				else
+				{
+					base.Id = System.Guid.Empty;
+				}
+				this.OnPropertyChanged("SdkMessageProcessingStepImageId");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepimageid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				this.SdkMessageProcessingStepImageId = value;
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message processing step image.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepimageidunique")]
+		public System.Nullable<System.Guid> SdkMessageProcessingStepImageIdUnique
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageprocessingstepimageidunique");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the associated solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public System.Nullable<System.Guid> SolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
+			}
+		}
+		
+		/// <summary>
+		/// Number that identifies a specific revision of the step image. 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
+		public System.Nullable<long> VersionNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 sdkmessageprocessingstepid_sdkmessageprocessingstepimage
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageprocessingstepid_sdkmessageprocessingstepimage")]
+		public SparkleXrm.Tasks.SdkMessageProcessingStep sdkmessageprocessingstepid_sdkmessageprocessingstepimage
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessageprocessingstepid_sdkmessageprocessingstepimage", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("sdkmessageprocessingstepid_sdkmessageprocessingstepimage");
+				this.SetRelatedEntity<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessageprocessingstepid_sdkmessageprocessingstepimage", null, value);
+				this.OnPropertyChanged("sdkmessageprocessingstepid_sdkmessageprocessingstepimage");
+			}
+		}
+	}
+	
+	/// <summary>
+	/// Non-public custom configuration that is passed to a plug-in's constructor.
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("sdkmessageprocessingstepsecureconfig")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class SdkMessageProcessingStepSecureConfig : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public SdkMessageProcessingStepSecureConfig() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "sdkmessageprocessingstepsecureconfig";
+		
+		public const int EntityTypeCode = 4616;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the SDK message processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the SDK message processing step was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the sdkmessageprocessingstepsecureconfig.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Customization level of the SDK message processing step secure configuration.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("customizationlevel")]
+		public System.Nullable<int> CustomizationLevel
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("customizationlevel");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who last modified the SDK message processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the SDK message processing step was last modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who last modified the sdkmessageprocessingstepsecureconfig.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the organization with which the SDK message processing step is associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
+		public Microsoft.Xrm.Sdk.EntityReference OrganizationId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message processing step secure configuration.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepsecureconfigid")]
+		public System.Nullable<System.Guid> SdkMessageProcessingStepSecureConfigId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageprocessingstepsecureconfigid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SdkMessageProcessingStepSecureConfigId");
+				this.SetAttributeValue("sdkmessageprocessingstepsecureconfigid", value);
+				if (value.HasValue)
+				{
+					base.Id = value.Value;
+				}
+				else
+				{
+					base.Id = System.Guid.Empty;
+				}
+				this.OnPropertyChanged("SdkMessageProcessingStepSecureConfigId");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepsecureconfigid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				this.SdkMessageProcessingStepSecureConfigId = value;
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the SDK message processing step.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sdkmessageprocessingstepsecureconfigidunique")]
+		public System.Nullable<System.Guid> SdkMessageProcessingStepSecureConfigIdUnique
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("sdkmessageprocessingstepsecureconfigidunique");
+			}
+		}
+		
+		/// <summary>
+		/// Secure step-specific configuration for the plug-in type that is passed to the plug-in's constructor at run time.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("secureconfig")]
+		public string SecureConfig
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("secureconfig");
+			}
+			set
+			{
+				this.OnPropertyChanging("SecureConfig");
+				this.SetAttributeValue("secureconfig", value);
+				this.OnPropertyChanged("SecureConfig");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStep> sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep");
+				this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep", null, value);
+				this.OnPropertyChanged("sdkmessageprocessingstepsecureconfigid_sdkmessageprocessingstep");
+			}
+		}
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum serviceendpoint_authtype
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		ACS = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		SASKey = 2,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		SASToken = 3,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		WebhookKey = 4,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		HttpHeader = 5,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		HttpQueryString = 6,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum serviceendpoint_connectionmode
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Normal = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Federated = 2,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum serviceendpoint_contract
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		OneWay = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Queue = 2,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Rest = 3,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		TwoWay = 4,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Topic = 5,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Queue_Persistent = 6,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		EventHub = 7,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Webhook = 8,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum serviceendpoint_messageformat
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		BinaryXML = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Json = 2,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		TextXML = 3,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum serviceendpoint_namespaceformat
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		NamespaceName = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		NamespaceAddress = 2,
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum serviceendpoint_userclaim
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		None = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		UserId = 2,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		UserInfo = 3,
+	}
+	
+	/// <summary>
+	/// Service endpoint that can be contacted.
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("serviceendpoint")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class ServiceEndpoint : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public ServiceEndpoint() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "serviceendpoint";
+		
+		public const int EntityTypeCode = 4618;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// Specifies mode of authentication with SB
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("authtype")]
+		public System.Nullable<SparkleXrm.Tasks.serviceendpoint_authtype> AuthType
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("authtype");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.serviceendpoint_authtype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.serviceendpoint_authtype), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("AuthType");
+				if ((value == null))
+				{
+					this.SetAttributeValue("authtype", null);
+				}
+				else
+				{
+					this.SetAttributeValue("authtype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("AuthType");
+			}
+		}
+		
+		/// <summary>
+		/// Authentication Value
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("authvalue")]
+		public string AuthValue
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("authvalue");
+			}
+			set
+			{
+				this.OnPropertyChanging("AuthValue");
+				this.SetAttributeValue("authvalue", value);
+				this.OnPropertyChanged("AuthValue");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
+		public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
+			}
+		}
+		
+		/// <summary>
+		/// Connection mode to contact the service endpoint.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("connectionmode")]
+		public System.Nullable<SparkleXrm.Tasks.serviceendpoint_connectionmode> ConnectionMode
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("connectionmode");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.serviceendpoint_connectionmode)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.serviceendpoint_connectionmode), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("ConnectionMode");
+				if ((value == null))
+				{
+					this.SetAttributeValue("connectionmode", null);
+				}
+				else
+				{
+					this.SetAttributeValue("connectionmode", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("ConnectionMode");
+			}
+		}
+		
+		/// <summary>
+		/// Type of the endpoint contract.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("contract")]
+		public System.Nullable<SparkleXrm.Tasks.serviceendpoint_contract> Contract
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("contract");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.serviceendpoint_contract)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.serviceendpoint_contract), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("Contract");
+				if ((value == null))
+				{
+					this.SetAttributeValue("contract", null);
+				}
+				else
+				{
+					this.SetAttributeValue("contract", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("Contract");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the service endpoint.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the service endpoint was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the service endpoint.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Description of the service endpoint.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
+		public string Description
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("description");
+			}
+			set
+			{
+				this.OnPropertyChanging("Description");
+				this.SetAttributeValue("description", value);
+				this.OnPropertyChanged("Description");
+			}
+		}
+		
+		/// <summary>
+		/// Version in which the form is introduced.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
+		public string IntroducedVersion
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("introducedversion");
+			}
+			set
+			{
+				this.OnPropertyChanging("IntroducedVersion");
+				this.SetAttributeValue("introducedversion", value);
+				this.OnPropertyChanged("IntroducedVersion");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isauthvalueset")]
+		public System.Nullable<bool> IsAuthValueSet
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isauthvalueset");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component can be customized.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomizable")]
+		public Microsoft.Xrm.Sdk.BooleanManagedProperty IsCustomizable
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("iscustomizable");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsCustomizable");
+				this.SetAttributeValue("iscustomizable", value);
+				this.OnPropertyChanged("IsCustomizable");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component is managed.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
+		public System.Nullable<bool> IsManaged
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("issaskeyset")]
+		public System.Nullable<bool> IsSASKeySet
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("issaskeyset");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("issastokenset")]
+		public System.Nullable<bool> IsSASTokenSet
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("issastokenset");
+			}
+		}
+		
+		/// <summary>
+		/// Content type of the message
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("messageformat")]
+		public System.Nullable<SparkleXrm.Tasks.serviceendpoint_messageformat> MessageFormat
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("messageformat");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.serviceendpoint_messageformat)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.serviceendpoint_messageformat), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("MessageFormat");
+				if ((value == null))
+				{
+					this.SetAttributeValue("messageformat", null);
+				}
+				else
+				{
+					this.SetAttributeValue("messageformat", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("MessageFormat");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who last modified the service endpoint.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the service endpoint was last modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who modified the service endpoint.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Name of Service end point.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
+		public string Name
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("name");
+			}
+			set
+			{
+				this.OnPropertyChanging("Name");
+				this.SetAttributeValue("name", value);
+				this.OnPropertyChanged("Name");
+			}
+		}
+		
+		/// <summary>
+		/// Full service endpoint address.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("namespaceaddress")]
+		public string NamespaceAddress
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("namespaceaddress");
+			}
+			set
+			{
+				this.OnPropertyChanging("NamespaceAddress");
+				this.SetAttributeValue("namespaceaddress", value);
+				this.OnPropertyChanged("NamespaceAddress");
+			}
+		}
+		
+		/// <summary>
+		/// Format of Service Bus Namespace
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("namespaceformat")]
+		public System.Nullable<SparkleXrm.Tasks.serviceendpoint_namespaceformat> NamespaceFormat
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("namespaceformat");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.serviceendpoint_namespaceformat)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.serviceendpoint_namespaceformat), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("NamespaceFormat");
+				if ((value == null))
+				{
+					this.SetAttributeValue("namespaceformat", null);
+				}
+				else
+				{
+					this.SetAttributeValue("namespaceformat", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("NamespaceFormat");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the organization with which the service endpoint is associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
+		public Microsoft.Xrm.Sdk.EntityReference OrganizationId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
+		public System.Nullable<System.DateTime> OverwriteTime
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
+			}
+		}
+		
+		/// <summary>
+		/// Path to the service endpoint.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("path")]
+		public string Path
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("path");
+			}
+			set
+			{
+				this.OnPropertyChanging("Path");
+				this.SetAttributeValue("path", value);
+				this.OnPropertyChanged("Path");
+			}
+		}
+		
+		/// <summary>
+		/// Shared Access Key
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("saskey")]
+		public string SASKey
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("saskey");
+			}
+			set
+			{
+				this.OnPropertyChanging("SASKey");
+				this.SetAttributeValue("saskey", value);
+				this.OnPropertyChanged("SASKey");
+			}
+		}
+		
+		/// <summary>
+		/// Shared Access Key Name
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("saskeyname")]
+		public string SASKeyName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("saskeyname");
+			}
+			set
+			{
+				this.OnPropertyChanging("SASKeyName");
+				this.SetAttributeValue("saskeyname", value);
+				this.OnPropertyChanged("SASKeyName");
+			}
+		}
+		
+		/// <summary>
+		/// Shared Access Token
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("sastoken")]
+		public string SASToken
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("sastoken");
+			}
+			set
+			{
+				this.OnPropertyChanging("SASToken");
+				this.SetAttributeValue("sastoken", value);
+				this.OnPropertyChanged("SASToken");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the service endpoint.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("serviceendpointid")]
+		public System.Nullable<System.Guid> ServiceEndpointId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("serviceendpointid");
+			}
+			set
+			{
+				this.OnPropertyChanging("ServiceEndpointId");
+				this.SetAttributeValue("serviceendpointid", value);
+				if (value.HasValue)
+				{
+					base.Id = value.Value;
+				}
+				else
+				{
+					base.Id = System.Guid.Empty;
+				}
+				this.OnPropertyChanged("ServiceEndpointId");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("serviceendpointid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				this.ServiceEndpointId = value;
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the service endpoint.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("serviceendpointidunique")]
+		public System.Nullable<System.Guid> ServiceEndpointIdUnique
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("serviceendpointidunique");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the associated solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public System.Nullable<System.Guid> SolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
+			}
+		}
+		
+		/// <summary>
+		/// Namespace of the App Fabric solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionnamespace")]
+		public string SolutionNamespace
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("solutionnamespace");
+			}
+			set
+			{
+				this.OnPropertyChanging("SolutionNamespace");
+				this.SetAttributeValue("solutionnamespace", value);
+				this.OnPropertyChanged("SolutionNamespace");
+			}
+		}
+		
+		/// <summary>
+		/// Full service endpoint Url.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("url")]
+		public string Url
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("url");
+			}
+			set
+			{
+				this.OnPropertyChanging("Url");
+				this.SetAttributeValue("url", value);
+				this.OnPropertyChanged("Url");
+			}
+		}
+		
+		/// <summary>
+		/// Additional user claim value type.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("userclaim")]
+		public System.Nullable<SparkleXrm.Tasks.serviceendpoint_userclaim> UserClaim
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("userclaim");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.serviceendpoint_userclaim)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.serviceendpoint_userclaim), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("UserClaim");
+				if ((value == null))
+				{
+					this.SetAttributeValue("userclaim", null);
+				}
+				else
+				{
+					this.SetAttributeValue("userclaim", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("UserClaim");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N serviceendpoint_sdkmessageprocessingstep
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("serviceendpoint_sdkmessageprocessingstep")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SdkMessageProcessingStep> serviceendpoint_sdkmessageprocessingstep
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("serviceendpoint_sdkmessageprocessingstep", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("serviceendpoint_sdkmessageprocessingstep");
+				this.SetRelatedEntities<SparkleXrm.Tasks.SdkMessageProcessingStep>("serviceendpoint_sdkmessageprocessingstep", null, value);
+				this.OnPropertyChanged("serviceendpoint_sdkmessageprocessingstep");
+			}
+		}
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum solution_solutiontype
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		None = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Snapshot = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Internal = 2,
+	}
+	
+	/// <summary>
+	/// A solution which contains CRM customizations.
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("solution")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class Solution : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public Solution() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "solution";
+		
+		public const int EntityTypeCode = 7100;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// A link to an optional configuration page for this solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("configurationpageid")]
+		public Microsoft.Xrm.Sdk.EntityReference ConfigurationPageId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("configurationpageid");
+			}
+			set
+			{
+				this.OnPropertyChanging("ConfigurationPageId");
+				this.SetAttributeValue("configurationpageid", value);
+				this.OnPropertyChanged("ConfigurationPageId");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the solution was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Description of the solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
+		public string Description
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("description");
+			}
+			set
+			{
+				this.OnPropertyChanging("Description");
+				this.SetAttributeValue("description", value);
+				this.OnPropertyChanged("Description");
+			}
+		}
+		
+		/// <summary>
+		/// User display name for the solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("friendlyname")]
+		public string FriendlyName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("friendlyname");
+			}
+			set
+			{
+				this.OnPropertyChanging("FriendlyName");
+				this.SetAttributeValue("friendlyname", value);
+				this.OnPropertyChanged("FriendlyName");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the solution was installed/upgraded.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("installedon")]
+		public System.Nullable<System.DateTime> InstalledOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("installedon");
+			}
+		}
+		
+		/// <summary>
+		/// Information about whether the solution is api managed.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isapimanaged")]
+		public System.Nullable<bool> IsApiManaged
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isapimanaged");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates whether the solution is managed or unmanaged.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
+		public System.Nullable<bool> IsManaged
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates whether the solution is visible outside of the platform.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isvisible")]
+		public System.Nullable<bool> IsVisible
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isvisible");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who last modified the solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the solution was last modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who modified the solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the organization associated with the solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
+		public Microsoft.Xrm.Sdk.EntityReference OrganizationId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the parent solution. Should only be non-null if this solution is a patch.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("parentsolutionid")]
+		public Microsoft.Xrm.Sdk.EntityReference ParentSolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("parentsolutionid");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pinpointassetid")]
+		public string PinpointAssetId
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("pinpointassetid");
+			}
+		}
+		
+		/// <summary>
+		/// Identifier of the publisher of this solution in Microsoft Pinpoint.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pinpointpublisherid")]
+		public System.Nullable<long> PinpointPublisherId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("pinpointpublisherid");
+			}
+		}
+		
+		/// <summary>
+		/// Default locale of the solution in Microsoft Pinpoint.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pinpointsolutiondefaultlocale")]
+		public string PinpointSolutionDefaultLocale
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("pinpointsolutiondefaultlocale");
+			}
+		}
+		
+		/// <summary>
+		/// Identifier of the solution in Microsoft Pinpoint.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("pinpointsolutionid")]
+		public System.Nullable<long> PinpointSolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("pinpointsolutionid");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the publisher.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("publisherid")]
+		public Microsoft.Xrm.Sdk.EntityReference PublisherId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("publisherid");
+			}
+			set
+			{
+				this.OnPropertyChanging("PublisherId");
+				this.SetAttributeValue("publisherid", value);
+				this.OnPropertyChanged("PublisherId");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public System.Nullable<System.Guid> SolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
+			}
+			set
+			{
+				this.OnPropertyChanging("SolutionId");
+				this.SetAttributeValue("solutionid", value);
+				if (value.HasValue)
+				{
+					base.Id = value.Value;
+				}
+				else
+				{
+					base.Id = System.Guid.Empty;
+				}
+				this.OnPropertyChanged("SolutionId");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				this.SolutionId = value;
+			}
+		}
+		
+		/// <summary>
+		/// Solution package source organization version
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionpackageversion")]
+		public string SolutionPackageVersion
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("solutionpackageversion");
+			}
+			set
+			{
+				this.OnPropertyChanging("SolutionPackageVersion");
+				this.SetAttributeValue("solutionpackageversion", value);
+				this.OnPropertyChanged("SolutionPackageVersion");
+			}
+		}
+		
+		/// <summary>
+		/// Solution Type
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutiontype")]
+		public System.Nullable<SparkleXrm.Tasks.solution_solutiontype> SolutionType
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("solutiontype");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.solution_solutiontype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.solution_solutiontype), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("SolutionType");
+				if ((value == null))
+				{
+					this.SetAttributeValue("solutiontype", null);
+				}
+				else
+				{
+					this.SetAttributeValue("solutiontype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("SolutionType");
+			}
+		}
+		
+		/// <summary>
+		/// The template suffix of this solution
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("templatesuffix")]
+		public string TemplateSuffix
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("templatesuffix");
+			}
+			set
+			{
+				this.OnPropertyChanging("TemplateSuffix");
+				this.SetAttributeValue("templatesuffix", value);
+				this.OnPropertyChanged("TemplateSuffix");
+			}
+		}
+		
+		/// <summary>
+		/// The unique name of this solution
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("uniquename")]
+		public string UniqueName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("uniquename");
+			}
+			set
+			{
+				this.OnPropertyChanging("UniqueName");
+				this.SetAttributeValue("uniquename", value);
+				this.OnPropertyChanged("UniqueName");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the solution was updated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("updatedon")]
+		public System.Nullable<System.DateTime> UpdatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("updatedon");
+			}
+		}
+		
+		/// <summary>
+		/// Contains component info for the solution upgrade operation
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("upgradeinfo")]
+		public string UpgradeInfo
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("upgradeinfo");
+			}
+		}
+		
+		/// <summary>
+		/// Solution version, used to identify a solution for upgrades and hotfixes.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("version")]
+		public string Version
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("version");
+			}
+			set
+			{
+				this.OnPropertyChanging("Version");
+				this.SetAttributeValue("version", value);
+				this.OnPropertyChanged("Version");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
+		public System.Nullable<long> VersionNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N solution_parent_solution
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solution_parent_solution", Microsoft.Xrm.Sdk.EntityRole.Referenced)]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.Solution> Referencedsolution_parent_solution
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.Solution>("solution_parent_solution", Microsoft.Xrm.Sdk.EntityRole.Referenced);
+			}
+			set
+			{
+				this.OnPropertyChanging("Referencedsolution_parent_solution");
+				this.SetRelatedEntities<SparkleXrm.Tasks.Solution>("solution_parent_solution", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
+				this.OnPropertyChanged("Referencedsolution_parent_solution");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N solution_solutioncomponent
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solution_solutioncomponent")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SolutionComponent> solution_solutioncomponent
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.SolutionComponent>("solution_solutioncomponent", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("solution_solutioncomponent");
+				this.SetRelatedEntities<SparkleXrm.Tasks.SolutionComponent>("solution_solutioncomponent", null, value);
+				this.OnPropertyChanged("solution_solutioncomponent");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 solution_configuration_webresource
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("configurationpageid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solution_configuration_webresource")]
+		public SparkleXrm.Tasks.WebResource solution_configuration_webresource
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.WebResource>("solution_configuration_webresource", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("solution_configuration_webresource");
+				this.SetRelatedEntity<SparkleXrm.Tasks.WebResource>("solution_configuration_webresource", null, value);
+				this.OnPropertyChanged("solution_configuration_webresource");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 solution_parent_solution
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("parentsolutionid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solution_parent_solution", Microsoft.Xrm.Sdk.EntityRole.Referencing)]
+		public SparkleXrm.Tasks.Solution Referencingsolution_parent_solution
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.Solution>("solution_parent_solution", Microsoft.Xrm.Sdk.EntityRole.Referencing);
+			}
+		}
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum solutioncomponent_rootcomponentbehavior
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		IncludeSubcomponents = 0,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Donotincludesubcomponents = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		IncludeAsShellOnly = 2,
+	}
+	
+	/// <summary>
+	/// A component of a CRM solution.
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("solutioncomponent")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class SolutionComponent : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public SolutionComponent() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "solutioncomponent";
+		
+		public const int EntityTypeCode = 7103;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// The object type code of the component.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componenttype")]
+		public Microsoft.Xrm.Sdk.OptionSetValue ComponentType
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componenttype");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the solution
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the solution was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates whether this component is metadata or data.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismetadata")]
+		public System.Nullable<bool> IsMetadata
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ismetadata");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who last modified the solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the solution was last modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who modified the solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the object with which the component is associated.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("objectid")]
+		public System.Nullable<System.Guid> ObjectId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("objectid");
+			}
+		}
+		
+		/// <summary>
+		/// Indicates the include behavior of the root component.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("rootcomponentbehavior")]
+		public System.Nullable<SparkleXrm.Tasks.solutioncomponent_rootcomponentbehavior> RootComponentBehavior
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("rootcomponentbehavior");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.solutioncomponent_rootcomponentbehavior)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.solutioncomponent_rootcomponentbehavior), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+		}
+		
+		/// <summary>
+		/// The parent ID of the subcomponent, which will be a root
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("rootsolutioncomponentid")]
+		public System.Nullable<System.Guid> RootSolutionComponentId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("rootsolutioncomponentid");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the solution component.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutioncomponentid")]
+		public System.Nullable<System.Guid> SolutionComponentId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("solutioncomponentid");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutioncomponentid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				base.Id = value;
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public Microsoft.Xrm.Sdk.EntityReference SolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("solutionid");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
+		public System.Nullable<long> VersionNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N solutioncomponent_parent_solutioncomponent
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solutioncomponent_parent_solutioncomponent", Microsoft.Xrm.Sdk.EntityRole.Referenced)]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.SolutionComponent> Referencedsolutioncomponent_parent_solutioncomponent
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.SolutionComponent>("solutioncomponent_parent_solutioncomponent", Microsoft.Xrm.Sdk.EntityRole.Referenced);
+			}
+			set
+			{
+				this.OnPropertyChanging("Referencedsolutioncomponent_parent_solutioncomponent");
+				this.SetRelatedEntities<SparkleXrm.Tasks.SolutionComponent>("solutioncomponent_parent_solutioncomponent", Microsoft.Xrm.Sdk.EntityRole.Referenced, value);
+				this.OnPropertyChanged("Referencedsolutioncomponent_parent_solutioncomponent");
+			}
+		}
+		
+		/// <summary>
+		/// N:1 solution_solutioncomponent
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solution_solutioncomponent")]
+		public SparkleXrm.Tasks.Solution solution_solutioncomponent
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.Solution>("solution_solutioncomponent", null);
+			}
+		}
+		
+		/// <summary>
+		/// N:1 solutioncomponent_parent_solutioncomponent
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("rootsolutioncomponentid")]
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solutioncomponent_parent_solutioncomponent", Microsoft.Xrm.Sdk.EntityRole.Referencing)]
+		public SparkleXrm.Tasks.SolutionComponent Referencingsolutioncomponent_parent_solutioncomponent
+		{
+			get
+			{
+				return this.GetRelatedEntity<SparkleXrm.Tasks.SolutionComponent>("solutioncomponent_parent_solutioncomponent", Microsoft.Xrm.Sdk.EntityRole.Referencing);
+			}
+		}
+	}
+	
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public enum webresource_webresourcetype
+	{
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Webpage_HTML = 1,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		StyleSheet_CSS = 2,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Script_JScript = 3,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Data_XML = 4,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		PNGformat = 5,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		JPGformat = 6,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		GIFformat = 7,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Silverlight_XAP = 8,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		StyleSheet_XSL = 9,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		ICOformat = 10,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		Vectorformat_SVG = 11,
+		
+		[System.Runtime.Serialization.EnumMemberAttribute()]
+		String_RESX = 12,
+	}
+	
+	/// <summary>
+	/// Data equivalent to files used in Web development. Web resources provide client-side components that are used to provide custom user interface elements.
+	/// </summary>
+	[System.Runtime.Serialization.DataContractAttribute()]
+	[Microsoft.Xrm.Sdk.Client.EntityLogicalNameAttribute("webresource")]
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class WebResource : Microsoft.Xrm.Sdk.Entity, System.ComponentModel.INotifyPropertyChanging, System.ComponentModel.INotifyPropertyChanged
+	{
+		
+		/// <summary>
+		/// Default Constructor.
+		/// </summary>
+		public WebResource() : 
+				base(EntityLogicalName)
+		{
+		}
+		
+		public const string EntityLogicalName = "webresource";
+		
+		public const int EntityTypeCode = 9333;
+		
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		
+		public event System.ComponentModel.PropertyChangingEventHandler PropertyChanging;
+		
+		private void OnPropertyChanged(string propertyName)
+		{
+			if ((this.PropertyChanged != null))
+			{
+				this.PropertyChanged(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+			}
+		}
+		
+		private void OnPropertyChanging(string propertyName)
+		{
+			if ((this.PropertyChanging != null))
+			{
+				this.PropertyChanging(this, new System.ComponentModel.PropertyChangingEventArgs(propertyName));
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component can be deleted.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("canbedeleted")]
+		public Microsoft.Xrm.Sdk.BooleanManagedProperty CanBeDeleted
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("canbedeleted");
+			}
+			set
+			{
+				this.OnPropertyChanging("CanBeDeleted");
+				this.SetAttributeValue("canbedeleted", value);
+				this.OnPropertyChanged("CanBeDeleted");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("componentstate")]
+		public Microsoft.Xrm.Sdk.OptionSetValue ComponentState
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("componentstate");
+			}
+		}
+		
+		/// <summary>
+		/// Bytes of the web resource, in Base64 format.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("content")]
+		public string Content
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("content");
+			}
+			set
+			{
+				this.OnPropertyChanging("Content");
+				this.SetAttributeValue("content", value);
+				this.OnPropertyChanged("Content");
+			}
+		}
+		
+		/// <summary>
+		/// Json representation of the content of the resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("contentjson")]
+		public string ContentJson
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("contentjson");
+			}
+			set
+			{
+				this.OnPropertyChanging("ContentJson");
+				this.SetAttributeValue("contentjson", value);
+				this.OnPropertyChanged("ContentJson");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who created the web resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the web resource was created.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdon")]
+		public System.Nullable<System.DateTime> CreatedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("createdon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who created the web resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("createdonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference CreatedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("createdonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("dependencyxml")]
+		public string DependencyXml
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("dependencyxml");
+			}
+			set
+			{
+				this.OnPropertyChanging("DependencyXml");
+				this.SetAttributeValue("dependencyxml", value);
+				this.OnPropertyChanged("DependencyXml");
+			}
+		}
+		
+		/// <summary>
+		/// Description of the web resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("description")]
+		public string Description
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("description");
+			}
+			set
+			{
+				this.OnPropertyChanging("Description");
+				this.SetAttributeValue("description", value);
+				this.OnPropertyChanged("Description");
+			}
+		}
+		
+		/// <summary>
+		/// Display name of the web resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("displayname")]
+		public string DisplayName
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("displayname");
+			}
+			set
+			{
+				this.OnPropertyChanging("DisplayName");
+				this.SetAttributeValue("displayname", value);
+				this.OnPropertyChanged("DisplayName");
+			}
+		}
+		
+		/// <summary>
+		/// Version in which the form is introduced.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("introducedversion")]
+		public string IntroducedVersion
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("introducedversion");
+			}
+			set
+			{
+				this.OnPropertyChanging("IntroducedVersion");
+				this.SetAttributeValue("introducedversion", value);
+				this.OnPropertyChanged("IntroducedVersion");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this web resource is available for mobile client in offline mode.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isavailableformobileoffline")]
+		public System.Nullable<bool> IsAvailableForMobileOffline
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isavailableformobileoffline");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsAvailableForMobileOffline");
+				this.SetAttributeValue("isavailableformobileoffline", value);
+				this.OnPropertyChanged("IsAvailableForMobileOffline");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component can be customized.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("iscustomizable")]
+		public Microsoft.Xrm.Sdk.BooleanManagedProperty IsCustomizable
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("iscustomizable");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsCustomizable");
+				this.SetAttributeValue("iscustomizable", value);
+				this.OnPropertyChanged("IsCustomizable");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this web resource is enabled for mobile client.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("isenabledformobileclient")]
+		public System.Nullable<bool> IsEnabledForMobileClient
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("isenabledformobileclient");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsEnabledForMobileClient");
+				this.SetAttributeValue("isenabledformobileclient", value);
+				this.OnPropertyChanged("IsEnabledForMobileClient");
+			}
+		}
+		
+		/// <summary>
+		/// Information that specifies whether this component should be hidden.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ishidden")]
+		public Microsoft.Xrm.Sdk.BooleanManagedProperty IsHidden
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.BooleanManagedProperty>("ishidden");
+			}
+			set
+			{
+				this.OnPropertyChanging("IsHidden");
+				this.SetAttributeValue("ishidden", value);
+				this.OnPropertyChanged("IsHidden");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("ismanaged")]
+		public System.Nullable<bool> IsManaged
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<bool>>("ismanaged");
+			}
+		}
+		
+		/// <summary>
+		/// Language of the web resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("languagecode")]
+		public System.Nullable<int> LanguageCode
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<int>>("languagecode");
+			}
+			set
+			{
+				this.OnPropertyChanging("LanguageCode");
+				this.SetAttributeValue("languagecode", value);
+				this.OnPropertyChanged("LanguageCode");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the user who last modified the web resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedby");
+			}
+		}
+		
+		/// <summary>
+		/// Date and time when the web resource was last modified.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedon")]
+		public System.Nullable<System.DateTime> ModifiedOn
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("modifiedon");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the delegate user who modified the web resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("modifiedonbehalfby")]
+		public Microsoft.Xrm.Sdk.EntityReference ModifiedOnBehalfBy
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("modifiedonbehalfby");
+			}
+		}
+		
+		/// <summary>
+		/// Name of the web resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("name")]
+		public string Name
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("name");
+			}
+			set
+			{
+				this.OnPropertyChanging("Name");
+				this.SetAttributeValue("name", value);
+				this.OnPropertyChanged("Name");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the organization associated with the web resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("organizationid")]
+		public Microsoft.Xrm.Sdk.EntityReference OrganizationId
+		{
+			get
+			{
+				return this.GetAttributeValue<Microsoft.Xrm.Sdk.EntityReference>("organizationid");
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("overwritetime")]
+		public System.Nullable<System.DateTime> OverwriteTime
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.DateTime>>("overwritetime");
+			}
+		}
+		
+		/// <summary>
+		/// Silverlight runtime version number required by a silverlight web resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("silverlightversion")]
+		public string SilverlightVersion
+		{
+			get
+			{
+				return this.GetAttributeValue<string>("silverlightversion");
+			}
+			set
+			{
+				this.OnPropertyChanging("SilverlightVersion");
+				this.SetAttributeValue("silverlightversion", value);
+				this.OnPropertyChanged("SilverlightVersion");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the associated solution.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("solutionid")]
+		public System.Nullable<System.Guid> SolutionId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("solutionid");
+			}
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("versionnumber")]
+		public System.Nullable<long> VersionNumber
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<long>>("versionnumber");
+			}
+		}
+		
+		/// <summary>
+		/// Unique identifier of the web resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("webresourceid")]
+		public System.Nullable<System.Guid> WebResourceId
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("webresourceid");
+			}
+			set
+			{
+				this.OnPropertyChanging("WebResourceId");
+				this.SetAttributeValue("webresourceid", value);
+				if (value.HasValue)
+				{
+					base.Id = value.Value;
+				}
+				else
+				{
+					base.Id = System.Guid.Empty;
+				}
+				this.OnPropertyChanged("WebResourceId");
+			}
+		}
+		
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("webresourceid")]
+		public override System.Guid Id
+		{
+			get
+			{
+				return base.Id;
+			}
+			set
+			{
+				this.WebResourceId = value;
+			}
+		}
+		
+		/// <summary>
+		/// For internal use only.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("webresourceidunique")]
+		public System.Nullable<System.Guid> WebResourceIdUnique
+		{
+			get
+			{
+				return this.GetAttributeValue<System.Nullable<System.Guid>>("webresourceidunique");
+			}
+		}
+		
+		/// <summary>
+		/// Drop-down list for selecting the type of the web resource.
+		/// </summary>
+		[Microsoft.Xrm.Sdk.AttributeLogicalNameAttribute("webresourcetype")]
+		public System.Nullable<SparkleXrm.Tasks.webresource_webresourcetype> WebResourceType
+		{
+			get
+			{
+				Microsoft.Xrm.Sdk.OptionSetValue optionSet = this.GetAttributeValue<Microsoft.Xrm.Sdk.OptionSetValue>("webresourcetype");
+				if ((optionSet != null))
+				{
+					return ((SparkleXrm.Tasks.webresource_webresourcetype)(System.Enum.ToObject(typeof(SparkleXrm.Tasks.webresource_webresourcetype), optionSet.Value)));
+				}
+				else
+				{
+					return null;
+				}
+			}
+			set
+			{
+				this.OnPropertyChanging("WebResourceType");
+				if ((value == null))
+				{
+					this.SetAttributeValue("webresourcetype", null);
+				}
+				else
+				{
+					this.SetAttributeValue("webresourcetype", new Microsoft.Xrm.Sdk.OptionSetValue(((int)(value))));
+				}
+				this.OnPropertyChanged("WebResourceType");
+			}
+		}
+		
+		/// <summary>
+		/// 1:N solution_configuration_webresource
+		/// </summary>
+		[Microsoft.Xrm.Sdk.RelationshipSchemaNameAttribute("solution_configuration_webresource")]
+		public System.Collections.Generic.IEnumerable<SparkleXrm.Tasks.Solution> solution_configuration_webresource
+		{
+			get
+			{
+				return this.GetRelatedEntities<SparkleXrm.Tasks.Solution>("solution_configuration_webresource", null);
+			}
+			set
+			{
+				this.OnPropertyChanging("solution_configuration_webresource");
+				this.SetRelatedEntities<SparkleXrm.Tasks.Solution>("solution_configuration_webresource", null, value);
+				this.OnPropertyChanged("solution_configuration_webresource");
+			}
+		}
+	}
+	
+	/// <summary>
+	/// Represents a source of entities bound to a CRM service. It tracks and manages changes made to the retrieved entities.
+	/// </summary>
+	[System.CodeDom.Compiler.GeneratedCodeAttribute("CrmSvcUtil", "9.1.0.28")]
+	public partial class OrganizationServiceContext1 : Microsoft.Xrm.Sdk.Client.OrganizationServiceContext
+	{
+		
+		/// <summary>
+		/// Constructor.
+		/// </summary>
+		public OrganizationServiceContext1(Microsoft.Xrm.Sdk.IOrganizationService service) : 
+				base(service)
+		{
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.CustomAPI"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.CustomAPI> CustomAPISet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.CustomAPI>();
+			}
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.PluginAssembly"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.PluginAssembly> PluginAssemblySet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.PluginAssembly>();
+			}
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.PluginType"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.PluginType> PluginTypeSet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.PluginType>();
+			}
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SdkMessage"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.SdkMessage> SdkMessageSet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.SdkMessage>();
+			}
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SdkMessageFilter"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.SdkMessageFilter> SdkMessageFilterSet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.SdkMessageFilter>();
+			}
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SdkMessagePair"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.SdkMessagePair> SdkMessagePairSet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.SdkMessagePair>();
+			}
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SdkMessageProcessingStep"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.SdkMessageProcessingStep> SdkMessageProcessingStepSet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.SdkMessageProcessingStep>();
+			}
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SdkMessageProcessingStepImage"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.SdkMessageProcessingStepImage> SdkMessageProcessingStepImageSet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.SdkMessageProcessingStepImage>();
+			}
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SdkMessageProcessingStepSecureConfig"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.SdkMessageProcessingStepSecureConfig> SdkMessageProcessingStepSecureConfigSet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.SdkMessageProcessingStepSecureConfig>();
+			}
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.ServiceEndpoint"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.ServiceEndpoint> ServiceEndpointSet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.ServiceEndpoint>();
+			}
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.Solution"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.Solution> SolutionSet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.Solution>();
+			}
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.SolutionComponent"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.SolutionComponent> SolutionComponentSet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.SolutionComponent>();
+			}
+		}
+		
+		/// <summary>
+		/// Gets a binding to the set of all <see cref="SparkleXrm.Tasks.WebResource"/> entities.
+		/// </summary>
+		public System.Linq.IQueryable<SparkleXrm.Tasks.WebResource> WebResourceSet
+		{
+			get
+			{
+				return this.CreateQuery<SparkleXrm.Tasks.WebResource>();
+			}
+		}
+	}
 }

--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -15,7 +15,11 @@ namespace SparkleXrm.Tasks
         private OrganizationServiceContext _ctx;
         private IOrganizationService _service;
         private ITrace _trace;
-
+        private static sdkmessageprocessingstep_stage[] SupportedPluginStages = new sdkmessageprocessingstep_stage[] {
+                sdkmessageprocessingstep_stage.Prevalidation, 
+                sdkmessageprocessingstep_stage.Preoperation,
+                sdkmessageprocessingstep_stage.Postoperation,
+                sdkmessageprocessingstep_stage.Postoperation_Deprecated };
         public PluginRegistraton(IOrganizationService service, OrganizationServiceContext context, ITrace trace)
         {
             _ctx = context;
@@ -308,17 +312,66 @@ namespace SparkleXrm.Tasks
 
                     foreach (var pluginAttribute in pluginAttributes)
                     {
-                        RegisterStep(sdkPluginType, existingSteps, pluginAttribute);
+                        var attribute = pluginAttribute.CreateFromData();
+                        if (attribute.Name == null && attribute.Message != null)
+                        {
+                            // Custom API registration
+                            RegisterCustomApi(sdkPluginType, existingSteps, attribute);
+                        }
+                        else
+                        {
+                            // Plugin Step registration
+                            RegisterStep(sdkPluginType, existingSteps, attribute);
+                        }
                     }
 
                     // Remove remaining Existing steps
                     foreach (var step in existingSteps)
                     {
-                        _trace.WriteLine("Deleting step '{0}'", step.Name, step.Stage);
-                        _service.Delete(SdkMessageProcessingStep.EntityLogicalName, step.Id);
+
+                        if (SupportedPluginStages.Contains(step.Stage??sdkmessageprocessingstep_stage.InitialPreoperation_Forinternaluseonly))
+                        {
+                            _trace.WriteLine("Deleting step '{0}'", step.Name, step.Stage);
+                            _service.Delete(SdkMessageProcessingStep.EntityLogicalName, step.Id);
+                        }
                     }
                 }
             }
+        }
+
+        private void RegisterCustomApi(PluginType sdkPluginType, List<SdkMessageProcessingStep> existingSteps, CrmPluginRegistrationAttribute attribute)
+        {
+            // Register against a Custom Api 
+            // Check it exists using the unqiue message name
+            var existingApi = (from s in _ctx.CreateQuery<CustomAPI>()
+                         where s.UniqueName == attribute.Message
+                         select new CustomAPI()
+                         {
+                             Id = s.Id,
+                             PluginTypeId = s.PluginTypeId
+                         }).ToList();
+            
+            if (existingApi.Count>0)
+            {
+                // Update Api Registration if it's a different type Id or null
+                var customApi = existingApi.First();
+                if (customApi.PluginTypeId?.Id != sdkPluginType.Id)
+                {
+                    customApi.PluginTypeId = sdkPluginType.ToEntityReference();
+                    _service.Update(customApi);
+
+                   _trace.WriteLine($"Registered Plugin Type {sdkPluginType.Id} against Custom Api '{attribute.Message}'");
+                }
+                else
+                {
+                    _trace.WriteLine($"Plugin Type {sdkPluginType.Id} is already registered against Custom Api '{attribute.Message}'");
+                }
+
+            }
+            else
+            {
+                _trace.WriteLine($"Warning: Cannot find custom api with UniqueName '{attribute.Message}'");
+            }  
         }
 
         private List<SdkMessageProcessingStep> GetExistingSteps(PluginType sdkPluginType)
@@ -348,10 +401,8 @@ namespace SparkleXrm.Tasks
             return steps;
         }
 
-        private void RegisterStep(PluginType sdkPluginType, List<SdkMessageProcessingStep> existingSteps, CustomAttributeData pluginAttribute)
+        private void RegisterStep(PluginType sdkPluginType, List<SdkMessageProcessingStep> existingSteps, CrmPluginRegistrationAttribute pluginStep)
         {
-            var pluginStep = pluginAttribute.CreateFromData();
-
             SdkMessageProcessingStep step = null;
             Guid stepId = Guid.Empty;
             if (pluginStep.Id != null)
@@ -399,7 +450,10 @@ namespace SparkleXrm.Tasks
             step.Configuration = pluginStep.UnSecureConfiguration;
             step.Description = pluginStep.Description;
             step.Mode = pluginStep.ExecutionMode == ExecutionModeEnum.Asynchronous ? sdkmessageprocessingstep_mode.Asynchronous : sdkmessageprocessingstep_mode.Synchronous;
-            step.AsyncAutoDelete = pluginStep.ExecutionMode == ExecutionModeEnum.Asynchronous ? pluginStep.DeleteAsyncOperation : false;
+            if (pluginStep.ExecutionMode == ExecutionModeEnum.Asynchronous)
+            {
+                step.AsyncAutoDelete = pluginStep.DeleteAsyncOperation;
+            }
             step.Rank = pluginStep.ExecutionOrder;
             int stage = 10;
             switch (pluginStep.Stage)
@@ -436,7 +490,7 @@ namespace SparkleXrm.Tasks
             step.SdkMessageFilterId = sdkMessagefilterId != null ? new EntityReference(SdkMessageFilter.EntityLogicalName, sdkMessagefilterId.Value) : null;
             step.SdkMessageId = new EntityReference(SdkMessage.EntityLogicalName, sdkMessageId.Value);
             step.FilteringAttributes = pluginStep.FilteringAttributes;
-            step.AsyncAutoDelete = pluginStep.DeleteAsyncOperation;
+           
             if (step.Id == Guid.Empty)
             {
                 _trace.WriteLine("Registering Step '{0}'", step.Name);

--- a/spkl/SparkleXrm.Tasks/Reflection.cs
+++ b/spkl/SparkleXrm.Tasks/Reflection.cs
@@ -71,7 +71,7 @@ namespace SparkleXrm.Tasks
             {
                 var data = type.GetCustomAttributesData().Where(a => a.AttributeType.Name == attributeName);
                 // Don't allow multiple steps with the same name per type
-                var duplicateNames = data.Select(a => a.CreateFromData()).GroupBy(s => s.Name).SelectMany(grp => grp.Skip(1));
+                var duplicateNames = data.Select(a => a.CreateFromData()).GroupBy(s => s.Name??"").SelectMany(grp => grp.Skip(1));
                 if (duplicateNames.Count() > 0)
                 {
                     var names = string.Join(", ", duplicateNames.Select(a => a.Name).ToArray());

--- a/spkl/SparkleXrm.Tasks/Tasks/DeployWebResourcesTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DeployWebResourcesTask.cs
@@ -277,7 +277,7 @@ namespace SparkleXrm.Tasks
                         filetype = webresource_webresourcetype.Vectorformat_SVG;
                         break;
                     case "resx":
-                        filetype = webresource_webresourcetype.Resourceformat_RESX;
+                        filetype = webresource_webresourcetype.String_RESX;
                         break;
                     default:
                         _trace.WriteLine("File extension '{0}' unexpected -> '{1}'", webResourceFileInfo.Extension, file.file);

--- a/spkl/SparkleXrm.Tasks/spkl.json
+++ b/spkl/SparkleXrm.Tasks/spkl.json
@@ -1,7 +1,7 @@
 ﻿{
   "earlyboundtypes": [
     {
-      "entities": "pluginassembly,plugintype,solution,webresource,solutioncomponent,sdkmessage,sdkmessagefilter,sdkmessagepair,sdkmessageprocessingstep,sdkmessageprocessingstepimage,sdkmessageprocessingstepsecureconfig,serviceendpoint",
+      "entities": "pluginassembly,plugintype,solution,webresource,solutioncomponent,sdkmessage,sdkmessagefilter,sdkmessagepair,sdkmessageprocessingstep,sdkmessageprocessingstepimage,sdkmessageprocessingstepsecureconfig,serviceendpoint,customapi",
       "generateOptionsetEnums": "true",
       "generateStateEnums": "true",
       "generateGlobalOptionsets": false,

--- a/spkl/TestPlugin/CustomApiPlugin.cs
+++ b/spkl/TestPlugin/CustomApiPlugin.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Xrm.Sdk;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TestPlugin
+{
+    // Test Custom API plugin registration
+    [CrmPluginRegistration("spkl_CustomApiTest")]
+    public class CustomApiPlugin : IPlugin
+    {
+        public void Execute(IServiceProvider serviceProvider)
+        {
+           
+        }
+    }
+}

--- a/spkl/TestPlugin/TestPlugin.csproj
+++ b/spkl/TestPlugin/TestPlugin.csproj
@@ -108,6 +108,7 @@
     <Compile Include="..\SparkleXrm.Tasks\CrmPluginRegistrationAttribute.cs">
       <Link>CrmPluginRegistrationAttribute.cs</Link>
     </Compile>
+    <Compile Include="CustomApiPlugin.cs" />
     <Compile Include="EarlyBoundTypes.cs" />
     <Compile Include="PluginBase.cs" />
     <Compile Include="PreValidateaccountUpdate.cs" />


### PR DESCRIPTION
Implements support for custom api plugins (#403)

A plugin is marked up for a custom API using:
```
[CrmPluginRegistration("spkl_CustomApiTest")]
    public class CustomApiPlugin : IPlugin
    {
        public void Execute(IServiceProvider serviceProvider)
        {
           
        }
    }
```

When running `deploy-plugins` the customapi is queried using the uniquename provided (e.g. spkl_CustomApiTest), if found and the current plugin is different (or empty), the plugin type is added to the existing customapi definition.