### PR TITLE
Added basic support for SDK style projects by mimicking previous behaviour of package.config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ UpgradeLog*.XML
 *.ide-wal
 /.vs
 /spkl/.vs/spkl
+*.nupkg

--- a/spkl/spkl/Package/spkl.nuspec
+++ b/spkl/spkl/Package/spkl.nuspec
@@ -13,11 +13,11 @@
     <releaseNotes>$releasenotes$</releaseNotes>
     <language>en-GB</language>
     <dependencies>
-		<dependency id="Microsoft.CrmSdk.CoreTools" version="9.1.0.25" />
+	    <dependency id="Microsoft.CrmSdk.CoreTools" version="9.1.0.25" />
     </dependencies>
   </metadata>
   <files>
-	<file src="..\..\SparkleXrm.Tasks\CrmPluginRegistrationAttribute.cs" target="content\CrmPluginRegistrationAttribute.cs" />
+    <file src="..\..\SparkleXrm.Tasks\CrmPluginRegistrationAttribute.cs" target="content\CrmPluginRegistrationAttribute.cs" />
     <file src="spkl\deploy-plugins.bat" target="content\spkl\deploy-plugins.bat" />
     <file src="spkl\deploy-webresources.bat" target="content\spkl\deploy-webresources.bat" />
     <file src="spkl\download-webresources.bat" target="content\spkl\download-webresources.bat" />
@@ -49,6 +49,6 @@
     <file src="..\bin\Release\spkl.CrmSvcUtilExtensions.dll" target="tools\spkl.CrmSvcUtilExtensions.dll" />
     <file src="..\bin\Release\spkl.exe" target="tools\spkl.exe" />
     <file src="..\bin\Release\spkl.exe.config" target="tools\spkl.exe.config" />
-	<file src="spkl.targets" target="build\spkl.targets" />
+    <file src="spkl.targets" target="build\spkl.targets" />
   </files>
 </package>

--- a/spkl/spkl/Package/spkl.nuspec
+++ b/spkl/spkl/Package/spkl.nuspec
@@ -13,7 +13,7 @@
     <releaseNotes>$releasenotes$</releaseNotes>
     <language>en-GB</language>
     <dependencies>
-	    <dependency id="Microsoft.CrmSdk.CoreTools" version="9.1.0.25" />
+	  <dependency id="Microsoft.CrmSdk.CoreTools" version="9.1.0.25" />
     </dependencies>
   </metadata>
   <files>

--- a/spkl/spkl/Package/spkl.nuspec
+++ b/spkl/spkl/Package/spkl.nuspec
@@ -13,11 +13,11 @@
     <releaseNotes>$releasenotes$</releaseNotes>
     <language>en-GB</language>
     <dependencies>
-      <dependency id="Microsoft.CrmSdk.CoreTools" version="9.1.0.25" />
+		<dependency id="Microsoft.CrmSdk.CoreTools" version="9.1.0.25" />
     </dependencies>
   </metadata>
   <files>
-    <file src="..\..\SparkleXrm.Tasks\CrmPluginRegistrationAttribute.cs" target="content\CrmPluginRegistrationAttribute.cs" />
+	<file src="..\..\SparkleXrm.Tasks\CrmPluginRegistrationAttribute.cs" target="content\CrmPluginRegistrationAttribute.cs" />
     <file src="spkl\deploy-plugins.bat" target="content\spkl\deploy-plugins.bat" />
     <file src="spkl\deploy-webresources.bat" target="content\spkl\deploy-webresources.bat" />
     <file src="spkl\download-webresources.bat" target="content\spkl\download-webresources.bat" />
@@ -49,5 +49,6 @@
     <file src="..\bin\Release\spkl.CrmSvcUtilExtensions.dll" target="tools\spkl.CrmSvcUtilExtensions.dll" />
     <file src="..\bin\Release\spkl.exe" target="tools\spkl.exe" />
     <file src="..\bin\Release\spkl.exe.config" target="tools\spkl.exe.config" />
+	<file src="spkl.targets" target="build\spkl.targets" />
   </files>
 </package>

--- a/spkl/spkl/Package/spkl.targets
+++ b/spkl/spkl/Package/spkl.targets
@@ -1,0 +1,42 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	
+	<Target Name="CopySpklArtefacts" BeforeTargets="Build">
+		<ItemGroup>
+			<SpklArtefacts Include="$(MSBuildThisFileDirectory)..\content\**\*.*" />
+		</ItemGroup>
+		<Copy
+          SourceFiles="@(SpklArtefacts)"
+          DestinationFolder="$(MSBuildProjectDirectory)\%(RecursiveDir)"
+          SkipUnchangedFiles="true"/>
+	</Target>
+
+	<ItemGroup>
+		<Content Include="$(MSBuildProjectDirectory)\spkl\**" />
+		<Content Include="$(MSBuildProjectDirectory)\CrmPluginRegistrationAttribute.cs" />
+		<Content Include="$(MSBuildProjectDirectory)\spkl.json" />
+	</ItemGroup>
+
+	<Target Name="CopySpklTools" BeforeTargets="Build">
+		<PropertyGroup>
+			<SpklVersion>$(MSBuildThisFileDirectory.Substring($(MSBuildThisFileDirectory.IndexOf('\spkl\'))).Replace('\spkl\','').Replace('\build\',''))</SpklVersion>
+		</PropertyGroup>
+		<ItemGroup>
+			<SpklTools Include="$(MSBuildThisFileDirectory)..\tools\*.*" />
+		</ItemGroup>
+		<Copy
+          SourceFiles="@(SpklTools)"
+          DestinationFolder="$(MSBuildProjectDirectory)\..\packages\spkl.$(SpklVersion)\tools\"
+          SkipUnchangedFiles="true"/>
+	</Target>
+
+	<Target Name="CopyCoreTools" BeforeTargets="Build">
+		<ItemGroup>
+			<CoreTools Include="$(MSBuildThisFileDirectory)..\..\..\microsoft.crmsdk.coretools\*\content\bin\coretools\*.*" />
+		</ItemGroup>
+		<Copy
+          SourceFiles="@(CoreTools)"
+          DestinationFolder="$(MSBuildProjectDirectory)\..\packages\Microsoft.CrmSdk.CoreTools.latest\content\bin\coretools"
+          SkipUnchangedFiles="true"/>
+	</Target>
+	
+</Project>

--- a/spkl/spkl/spkl.csproj
+++ b/spkl/spkl/spkl.csproj
@@ -44,6 +44,7 @@
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.5.2.4\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.1.0.38\lib\net462\Microsoft.Rest.ClientRuntime.dll</HintPath>
@@ -67,6 +68,7 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -74,9 +76,11 @@
     <Reference Include="System.Activities.Presentation" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.7.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
@@ -86,27 +90,29 @@
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
       <Private>True</Private>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Extensions, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.Extensions.4.3.1\lib\net462\System.Runtime.Extensions.dll</HintPath>
-      <Private>True</Private>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
@@ -114,17 +120,17 @@
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
       <Private>True</Private>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.2\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
-      <Private>True</Private>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ServiceModel" />
@@ -155,17 +161,8 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="bin\coretools\CrmSvcUtil.exe.config" />
-    <None Include="bin\coretools\LicenseTerms.docx" />
-    <None Include="bin\coretools\SolutionPackager.exe.config" />
-    <None Include="bin\Debug\CrmSvcUtil.exe.config" />
-    <None Include="bin\Debug\SparkleXrm.Tasks.dll.config" />
-    <None Include="bin\Debug\spkl.crmsvcutil.config" />
-    <None Include="bin\Debug\spkl.CrmSvcUtilExtensions.dll.config" />
-    <None Include="bin\Debug\spkl.exe.config" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
+    <None Include="Package\spkl.targets" />
     <None Include="Package\spkl\download-webresources.bat" />
     <None Include="Package\spkl\instrument-plugin-code.bat" />
     <None Include="Package\spkl\earlybound.bat" />
@@ -191,62 +188,7 @@
       <Name>SparkleXrm.Tasks</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="bin\coretools\CrmSvcUtil.exe" />
-    <Content Include="bin\coretools\CrmSvcUtil.xml" />
-    <Content Include="bin\coretools\Microsoft.ApplicationInsights.dll" />
-    <Content Include="bin\coretools\Microsoft.Crm.Sdk.Proxy.dll" />
-    <Content Include="bin\coretools\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
-    <Content Include="bin\coretools\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" />
-    <Content Include="bin\coretools\Microsoft.PowerApps.AppInsights.BatchedTelemetry.dll" />
-    <Content Include="bin\coretools\Microsoft.PowerApps.AppInsights.BatchedTelemetryChannel.dll" />
-    <Content Include="bin\coretools\Microsoft.Rest.ClientRuntime.dll" />
-    <Content Include="bin\coretools\Microsoft.Xrm.Sdk.Deployment.dll" />
-    <Content Include="bin\coretools\Microsoft.Xrm.Sdk.dll" />
-    <Content Include="bin\coretools\Microsoft.Xrm.Tooling.Connector.dll" />
-    <Content Include="bin\coretools\Microsoft.Xrm.Tooling.CrmConnectControl.dll" />
-    <Content Include="bin\coretools\Microsoft.Xrm.Tooling.Ui.Styles.dll" />
-    <Content Include="bin\coretools\Newtonsoft.Json.dll" />
-    <Content Include="bin\coretools\Other Redistributable.txt" />
-    <Content Include="bin\coretools\pacTelemetryUpload.exe" />
-    <Content Include="bin\coretools\SolutionPackager.exe" />
-    <Content Include="bin\coretools\SolutionPackagerLib.dll" />
-    <Content Include="bin\coretools\System.Diagnostics.DiagnosticSource.dll" />
-    <Content Include="bin\coretools\System.ValueTuple.dll" />
-    <Content Include="bin\Debug\CmdLine.dll" />
-    <Content Include="bin\Debug\CrmSvcUtil.exe" />
-    <Content Include="bin\Debug\CrmSvcUtil.xml" />
-    <Content Include="bin\Debug\Microsoft.Crm.Sdk.Proxy.dll" />
-    <Content Include="bin\Debug\Microsoft.Crm.Sdk.Proxy.xml" />
-    <Content Include="bin\Debug\Microsoft.Extensions.FileSystemGlobbing.dll" />
-    <Content Include="bin\Debug\Microsoft.Extensions.FileSystemGlobbing.xml" />
-    <Content Include="bin\Debug\Microsoft.IdentityModel.Clients.ActiveDirectory.dll" />
-    <Content Include="bin\Debug\Microsoft.IdentityModel.Clients.ActiveDirectory.pdb" />
-    <Content Include="bin\Debug\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll" />
-    <Content Include="bin\Debug\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.pdb" />
-    <Content Include="bin\Debug\Microsoft.IdentityModel.Clients.ActiveDirectory.xml" />
-    <Content Include="bin\Debug\Microsoft.IdentityModel.dll" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Deployment.dll" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Deployment.xml" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.dll" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Workflow.dll" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Workflow.xml" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.xml" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Tooling.Connector.dll" />
-    <Content Include="bin\Debug\Microsoft.Xrm.Tooling.Connector.xml" />
-    <Content Include="bin\Debug\netstandard.dll" />
-    <Content Include="bin\Debug\Newtonsoft.Json.dll" />
-    <Content Include="bin\Debug\Newtonsoft.Json.xml" />
-    <Content Include="bin\Debug\SparkleXrm.Tasks.dll" />
-    <Content Include="bin\Debug\SparkleXrm.Tasks.pdb" />
-    <Content Include="bin\Debug\spkl.CrmSvcUtilExtensions.dll" />
-    <Content Include="bin\Debug\spkl.CrmSvcUtilExtensions.pdb" />
-    <Content Include="bin\Debug\spkl.exe" />
-    <Content Include="bin\Debug\spkl.pdb" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="bin\Release\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Upon build, a .targets file copies CoreTools and Spkl from "C:\Users\<USERNAME>\.nuget\packages\" to a packages folder at the solution level.
Due to the new limitations on nuget restore and PackageReference, the project needs to be built before or the Spkl artifacts will be copied across.