### PR TITLE
🐛 Force optionset label to 1033 since it's hard coded in CrmSvcUtil

### DIFF
--- a/spkl/CrmSvcUtilFilteringService/FilteringService.cs
+++ b/spkl/CrmSvcUtilFilteringService/FilteringService.cs
@@ -70,9 +70,12 @@
                     }
 
                     // Set all languages to the user localised version
+                    // This is so that no matter what languages are defined, the user's language is picked up
+                    // 1033 is hard coded in to the default naming service of CrmSvcUtil
                     foreach (var label in option.Label.LocalizedLabels)
                     {
                         label.Label = option.Label.UserLocalizedLabel.Label;
+                        label.LanguageCode = 1033;
                     }
                 }
 
@@ -85,6 +88,8 @@
                     foreach (var label in option.Label.LocalizedLabels)
                     {
                         label.Label = option.Label.UserLocalizedLabel.Label;
+                        // 1033 is hard coded in to the default naming service of CrmSvcUtil
+                        label.LanguageCode = 1033;
                     }
                 });  
             }


### PR DESCRIPTION
I have reproduced issue #349.
The reason that we get UnknownLabel is that the Naming Service provided by default hard codes the language code of 1033 (en-us).
The PR from @JannyM85 implements a custom naming service that picks the language using a command-line argument.
my idea is to use as much of the standard CrmSvcUtil as possible, and so I'm proposing simply using the language of the user to determine which language to use, and then forcing the Language Code to 1033 so that the default naming service picks it up. This will result in the smallest number of changes in terms of code.