### PR TITLE
Feature/update core tools fixes

### DIFF
--- a/spkl/SparkleXrm.Tasks/CodeParser.cs
+++ b/spkl/SparkleXrm.Tasks/CodeParser.cs
@@ -24,7 +24,8 @@ namespace SparkleXrm.Tasks
         #endregion
 
         #region Private Constants
-        private string _classRegex = @"((public( sealed)? class (?'class'[\w]*)[\W]*?)((?'plugin':[\W]*?((IPlugin)|(PluginBase)|(Plugin)))|(?'wf':[\W]*?CodeActivity)))";
+        // Class regex adapted to cater for derived plugin classes which implement IPlugin
+        private string _classRegex = @"((public( sealed)? class (?'class'[\w]*)[\W]*?)((?'plugin':.*((IPlugin)|(PluginBase)|(Plugin)))|(?'wf':[\W]*?CodeActivity)))";
         private const string _attributeRegex = @"([ ]*?)\[CrmPluginRegistration\(([\W\w\s]+?)(\)\])([ ]*?(\r\n|\r|\n))";
         private const string _namespaceRegEx = @"namespace (?'ns'[\w.]*)";
         #endregion

--- a/spkl/SparkleXrm.Tasks/Config/ConfigFile.cs
+++ b/spkl/SparkleXrm.Tasks/Config/ConfigFile.cs
@@ -22,10 +22,12 @@ namespace SparkleXrm.Tasks.Config
         public virtual void Save()
         {
             var file = Path.Combine(filePath, "spkl.json");
-            if (File.Exists(file))
-            {
-                File.Copy(file, file + DateTime.Now.ToString("yyyyMMddHHmmss") + ".bak");
-            }
+
+            /* No need to make a backup copy - with Git you can always undo a commit to revert any changes */
+            //if (File.Exists(file))
+            //{
+            //    File.Copy(file, file + DateTime.Now.ToString("yyyyMMddHHmmss") + ".bak");
+            //}
             File.WriteAllText(file, Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented, new JsonSerializerSettings
             {
                 NullValueHandling = NullValueHandling.Ignore

--- a/spkl/SparkleXrm.Tasks/Tasks/DownloadPluginMetadataTask.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/DownloadPluginMetadataTask.cs
@@ -187,7 +187,7 @@ namespace SparkleXrm.Tasks
                             )
                         {
                             Id = step.Id.ToString(),
-                            DeleteAsyncOperation = step.Mode.Value != 0 && step.AsyncAutoDelete.Value,
+                            DeleteAsyncOperation = step.Mode == sdkmessageprocessingstep_mode.Asynchronous && step.AsyncAutoDelete == true,
                         };
                     }
 

--- a/spkl/SparkleXrm.Tasks/Tasks/Queries.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/Queries.cs
@@ -25,6 +25,7 @@ namespace SparkleXrm.Tasks
                         SdkMessageProcessingStepId = s.SdkMessageProcessingStepId,
                         Name = s.Name,
                         Mode = s.Mode,
+                        AsyncAutoDelete = s.AsyncAutoDelete,
                         FilteringAttributes = s.FilteringAttributes,
                         Rank = s.Rank,
                         Stage = s.Stage,


### PR DESCRIPTION
Changes:
* The query for getting plugin step information didn't read the AsyncAutoDelete attribute which made SPKL crash on async plugin steps. Fixed.
* Plugins classes which derive not directly from Plugin or PluginBase but from another base plugin class, are not recognized. The class regex is adapted so that these classes do match as long as they implement IPlugin
* The code to create backup files during instrumenting is disabled to prevent a buildup of .bak files. Backup files are technically not needed with version control systems like Git, since one can always revert a change made by SPKL.