### PR TITLE
Vs2017 build

### DIFF
--- a/SparkleXrmSamples/ConnectionsUI/ClientUI.UnitTests/ClientUI.UnitTests.csproj
+++ b/SparkleXrmSamples/ConnectionsUI/ClientUI.UnitTests/ClientUI.UnitTests.csproj
@@ -18,6 +18,7 @@
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\</OutputPath>

--- a/SparkleXrmSamples/MultiEntitySearch/ClientHooks/ClientHooks.csproj
+++ b/SparkleXrmSamples/MultiEntitySearch/ClientHooks/ClientHooks.csproj
@@ -14,6 +14,7 @@
     <CodeAnalysisRuleSet>Properties\FxCop.ruleset</CodeAnalysisRuleSet>
     <GenerateScript>True</GenerateScript>
     <GenerateResources>True</GenerateResources>
+	<DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\SparkleXrmCrmPackage\CrmPackage\WebResources\js\</OutputPath>

--- a/SparkleXrmSamples/MultiEntitySearch/ClientUI/ClientUI.csproj
+++ b/SparkleXrmSamples/MultiEntitySearch/ClientUI/ClientUI.csproj
@@ -14,6 +14,7 @@
     <CodeAnalysisRuleSet>Properties\FxCop.ruleset</CodeAnalysisRuleSet>
     <GenerateScript>True</GenerateScript>
     <GenerateResources>True</GenerateResources>
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\SparkleXrmCrmPackage\CrmPackage\WebResources\js\</OutputPath>

--- a/SparkleXrmSamples/QuickNavigation/ClientHooks/ClientHooks.csproj
+++ b/SparkleXrmSamples/QuickNavigation/ClientHooks/ClientHooks.csproj
@@ -16,6 +16,7 @@
     <GenerateResources>True</GenerateResources>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\SparkleXrmCrmPackage\CrmPackage\WebResources\js\</OutputPath>

--- a/SparkleXrmSamples/QuickNavigation/ClientUI/ClientUI.csproj
+++ b/SparkleXrmSamples/QuickNavigation/ClientUI/ClientUI.csproj
@@ -16,6 +16,7 @@
     <GenerateResources>True</GenerateResources>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\SparkleXrmCrmPackage\CrmPackage\WebResources\js\</OutputPath>

--- a/SparkleXrmSamples/QuoteLineEditor/ClientHooks/ClientHooks.csproj
+++ b/SparkleXrmSamples/QuoteLineEditor/ClientHooks/ClientHooks.csproj
@@ -16,6 +16,7 @@
     <GenerateResources>True</GenerateResources>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\QuoteLineEditor\CrmPackage\WebResources\dev1_\js\</OutputPath>

--- a/SparkleXrmSamples/QuoteLineEditor/ClientUI/ClientUI.csproj
+++ b/SparkleXrmSamples/QuoteLineEditor/ClientUI/ClientUI.csproj
@@ -16,6 +16,7 @@
     <GenerateResources>True</GenerateResources>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\QuoteLineEditor\CrmPackage\WebResources\dev1_\js\</OutputPath>

--- a/SparkleXrmSamples/SparkleXrmTemplate/ClientHooks/ClientHooks.csproj
+++ b/SparkleXrmSamples/SparkleXrmTemplate/ClientHooks/ClientHooks.csproj
@@ -16,6 +16,7 @@
     <GenerateResources>True</GenerateResources>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\SparkleXrmCrmPackage\CrmPackage\WebResources\js\</OutputPath>

--- a/SparkleXrmSamples/SparkleXrmTemplate/ClientUI/ClientUI.csproj
+++ b/SparkleXrmSamples/SparkleXrmTemplate/ClientUI/ClientUI.csproj
@@ -16,6 +16,7 @@
     <GenerateResources>True</GenerateResources>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\SparkleXrmCrmPackage\CrmPackage\WebResources\js\</OutputPath>

--- a/SparkleXrmSamples/SparkleXrmTemplateCRM2015/ClientHooks/ClientHooks.csproj
+++ b/SparkleXrmSamples/SparkleXrmTemplateCRM2015/ClientHooks/ClientHooks.csproj
@@ -18,6 +18,7 @@
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\SparkleXrmCrmPackage\CrmPackage\WebResources\js\</OutputPath>

--- a/SparkleXrmSamples/SparkleXrmTemplateCRM2015/ClientUI/ClientUI.csproj
+++ b/SparkleXrmSamples/SparkleXrmTemplateCRM2015/ClientUI/ClientUI.csproj
@@ -18,6 +18,7 @@
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\SparkleXrmCrmPackage\CrmPackage\WebResources\js\</OutputPath>

--- a/SparkleXrmSamples/SparkleXrmTemplateCRM2015WithUnitTests/ClientHooks/ClientHooks.csproj
+++ b/SparkleXrmSamples/SparkleXrmTemplateCRM2015WithUnitTests/ClientHooks/ClientHooks.csproj
@@ -18,6 +18,7 @@
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\SparkleXrmCrmPackage\CrmPackage\WebResources\js\</OutputPath>

--- a/SparkleXrmSamples/SparkleXrmTemplateCRM2015WithUnitTests/ClientUI.UnitTests/ClientUI.UnitTests.csproj
+++ b/SparkleXrmSamples/SparkleXrmTemplateCRM2015WithUnitTests/ClientUI.UnitTests/ClientUI.UnitTests.csproj
@@ -18,6 +18,7 @@
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\</OutputPath>

--- a/SparkleXrmSamples/SparkleXrmTemplateCRM2015WithUnitTests/ClientUI/ClientUI.csproj
+++ b/SparkleXrmSamples/SparkleXrmTemplateCRM2015WithUnitTests/ClientUI/ClientUI.csproj
@@ -18,6 +18,7 @@
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\SparkleXrmCrmPackage\CrmPackage\WebResources\js\</OutputPath>

--- a/SparkleXrmSamples/SparkleXrmTemplateVS2015/ClientHooks/ClientHooks.csproj
+++ b/SparkleXrmSamples/SparkleXrmTemplateVS2015/ClientHooks/ClientHooks.csproj
@@ -14,6 +14,7 @@
     <CodeAnalysisRuleSet>Properties\FxCop.ruleset</CodeAnalysisRuleSet>
     <GenerateScript>True</GenerateScript>
     <GenerateResources>True</GenerateResources>
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\CrmPackage\WebResources\js\</OutputPath>

--- a/SparkleXrmSamples/SparkleXrmTemplateVS2015/ClientUI/ClientUI.csproj
+++ b/SparkleXrmSamples/SparkleXrmTemplateVS2015/ClientUI/ClientUI.csproj
@@ -14,6 +14,7 @@
     <CodeAnalysisRuleSet>Properties\FxCop.ruleset</CodeAnalysisRuleSet>
     <GenerateScript>True</GenerateScript>
     <GenerateResources>True</GenerateResources>
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\CrmPackage\WebResources\js\</OutputPath>

--- a/SparkleXrmSource/SparkleXrm/ES6/Promise.cs
+++ b/SparkleXrmSource/SparkleXrm/ES6/Promise.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace ES6
+{
+    [Imported]
+    [IgnoreNamespace]
+    public class Promise
+    {
+        public Promise(PromiseArgs promise)
+        {
+        }
+
+        public static Promise Resolve(object value)
+        {
+            return null;
+        }
+        
+        [ScriptName("then")]
+        public Promise Then(Func<object, Promise> onFulfilled)
+        {
+            return null;
+        }
+        
+        [ScriptName("then")]
+        public Promise Then2(Action<object, Promise> onFulfilled, Action<Exception> onRejected)
+        {
+            return null;
+        }
+        
+        [ScriptName("then")]
+        public Promise Then3(Action<object> onFulfilled)
+        {
+            return null;
+        }
+        
+        public Promise Catch(Action<Exception> onRejected)
+        {
+            return null;
+        }
+        
+        public static Promise Resolve(Promise promise)
+        {
+            return null;
+        }
+        
+        public static Promise Reject(Exception error)
+        {
+            return null;
+        }
+        
+        public static Promise All(List<Promise> all)
+        {
+            return null;
+        }
+        
+        public static Promise Race(List<Promise> reace)
+        {
+            return null;
+        }
+    }
+
+    [Imported]
+    public delegate void PromiseArgs(Action<object> resolve, Action<Exception> reject);
+}

--- a/SparkleXrmSource/SparkleXrmUI/SparkleXrmUI.csproj
+++ b/SparkleXrmSource/SparkleXrmUI/SparkleXrmUI.csproj
@@ -40,6 +40,7 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <DisableHandlePackageFileConflicts>true</DisableHandlePackageFileConflicts>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\Debug\</OutputPath>


### PR DESCRIPTION
Enable building ScriptSharp projects in VS 2017. Also added Promise.cs, as that file was missing and preventing successful build.

https://github.com/nikhilk/scriptsharp/issues/452
https://developercommunity.visualstudio.com/content/problem/138986/1550-preview-2-breaks-scriptsharp-compilation.html

#344 