### PR TITLE
Fixing #454 nullable object error

### DIFF
--- a/spkl/SparkleXrm.Tasks/Tasks/Queries.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/Queries.cs
@@ -31,6 +31,7 @@ namespace SparkleXrm.Tasks
                         SdkMessageFilterId = s.SdkMessageFilterId,
                         Configuration = s.Configuration,
                         Description = s.Description,
+                        AsyncAutoDelete = s.AsyncAutoDelete,
                         sdkmessageid_sdkmessageprocessingstep = new SdkMessage
                         {
                             SdkMessageId = m.SdkMessageId,


### PR DESCRIPTION
Fixing issue #454. DownloadPluginMetadataTask.AddPluginAttributes would throw an exception on async plugin tasks because the LINQ projection forgot to include the AsyncAutoDelete attribute.