### PR TITLE
Enable Office365 Auth from GCC-High and DoD Closed #466

### DIFF
--- a/spkl/spkl/XrmToolingCmdLine/XrmToolingConnection.cs
+++ b/spkl/spkl/XrmToolingCmdLine/XrmToolingConnection.cs
@@ -78,7 +78,7 @@ namespace SparkleXrmTask.XrmToolingCmdLine
             if (newConnection)
             {
                 selectedConnection = new SavedConnection();
-                var envUrl = ReadLine("Environment/Organization Url (e.g. org123.crm.dynamics.com)", regex: @"^(?<!http)([^\s:\/]+)(\.crm[0-9]*\.dynamics\.com[\/]?)$");
+                var envUrl = ReadLine("Environment/Organization Url (e.g. org123.crm.dynamics.com)", regex: @"^(?<!http)([^\s:\/]+)(\.crm[0-9]*\.(dynamics\.com|microsoftdynamics\.us|appsplatform\.us)[\/]?)$");
                 envUrl = envUrl.TrimEnd('/');
                 selectedConnection.EnvironmentUrl = envUrl;
                 // If new connection - set LoginPrompt=Always


### PR DESCRIPTION
Updated the regex that validates the Uri for the environment to include the patterns for GCC-High and DoD.

Closes #466 