### PR TITLE
Fix instrumnetation for Async plugins

### DIFF
--- a/spkl/SparkleXrm.Tasks/CustomAttributeDataEx.cs
+++ b/spkl/SparkleXrm.Tasks/CustomAttributeDataEx.cs
@@ -157,7 +157,7 @@ namespace SparkleXrm.Tasks
                 additionalParmeters += indentation + ",Id = \"" + attribute.Id + "\"";
 
             if (attribute.ExecutionMode == ExecutionModeEnum.Asynchronous && attribute.DeleteAsyncOperation == true)
-                additionalParmeters += indentation + ",DeleteAsyncOperation = " + attribute.DeleteAsyncOperation;
+                additionalParmeters += indentation + ",DeleteAsyncOperation = " + attribute.DeleteAsyncOperation.ToString().ToLower();
 
             if (attribute.UnSecureConfiguration != null)
                 additionalParmeters += indentation + ",UnSecureConfiguration = @\"" + attribute.UnSecureConfiguration.Replace("\"","\"\"") + "\"";

--- a/spkl/SparkleXrm.Tasks/Tasks/Queries.cs
+++ b/spkl/SparkleXrm.Tasks/Tasks/Queries.cs
@@ -31,6 +31,7 @@ namespace SparkleXrm.Tasks
                         SdkMessageFilterId = s.SdkMessageFilterId,
                         Configuration = s.Configuration,
                         Description = s.Description,
+                        AsyncAutoDelete = s.AsyncAutoDelete,
                         sdkmessageid_sdkmessageprocessingstep = new SdkMessage
                         {
                             SdkMessageId = m.SdkMessageId,


### PR DESCRIPTION
Fixes issue #484
- the steps query was missing the `AsyncAutoDelete` which threw a null-reference exception later down the line
- ensure generated code is C# compatible (lowercase `true` for `DeleteAsyncOperation`)