### PR TITLE
Added image support for bulk message steps during plug-in registration

### DIFF
--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -568,6 +568,11 @@ namespace SparkleXrm.Tasks
                     image.MessagePropertyName = "EmailId";
                     break;
 
+                case "CreateMultiple":
+                case "UpdateMultiple":
+                    image.MessagePropertyName = "Targets";
+                    break;
+                    
                 default:
                     image.MessagePropertyName = "Target";
                     break;


### PR DESCRIPTION
Updated the plug-in registration to support images being registered to the 'targets' property name when assigned to a CreateMultiple or UpdateMultiple plug-in step as opposed to 'target'.

#486  
