### PR TITLE
Added image support for bulk message steps during plug-in registration

### DIFF
--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -569,6 +569,9 @@ namespace SparkleXrm.Tasks
                     break;
 
                 case "CreateMultiple":
+                    image.MessagePropertyName = "Ids";
+                    break;
+                    
                 case "UpdateMultiple":
                     image.MessagePropertyName = "Targets";
                     break;

--- a/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
+++ b/spkl/SparkleXrm.Tasks/PluginRegistraton.cs
@@ -568,6 +568,11 @@ namespace SparkleXrm.Tasks
                     image.MessagePropertyName = "EmailId";
                     break;
 
+                case "CreateMultiple":
+                case "UpdateMultiple":
+                    image.MessagePropertyName = "Targets";
+                    break;
+                    
                 default:
                     image.MessagePropertyName = "Target";
                     break;


### PR DESCRIPTION
Updated the plug-in registration to support images being registered to the 'Targets' property name when assigned to a UpdateMultiple plug-in step as opposed to 'target'.

Updated the plug-in registration to support images being registered to the 'Ids' property name when assigned to a CreateMultiple plug-in step as opposed to 'target'.

#486 
#487 